### PR TITLE
Add hpe 3par backend support

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,3 +260,63 @@ sudo snap set cinder-volume \
   dellpowerstore.powerstore1.protocol=iscsi \
   dellpowerstore.powerstore1.replication-device='backend_id:powerstore1_rep,san_ip:10.20.30.50,san_login:admin,san_password:password'
 ```
+
+
+### HPE 3Par Driver (backend)
+
+Configure one or more HPE 3Par backends using the `hpe3par.<backend-name>.*` namespace:
+
+**Required options:**
+* `hpe3par.<backend-name>.volume-backend-name`  Unique name for this backend
+* `hpe3par.<backend-name>.san-ip`               HPE 3Par management IP
+* `hpe3par.<backend-name>.san-login`            HPE 3Par management username 
+* `hpe3par.<backend-name>.san-password`         HPE 3Par management password
+
+**Protocol configuration:**
+* `hpe3par.<backend-name>.protocol`     Protocol (`iscsi`, `fc`) – default `fc`
+
+**Driver options:**
+* `hpe3par.<backend-name>.hpe3par-api-url`       HPE 3Par WSAPI url
+* `hpe3par.<backend-name>.hpe3par-username`      HPE 3Par user with admin role
+* `hpe3par.<backend-name>.hpe3par-password`      HPE 3Par password for the specified user
+* `hpe3par.<backend-name>.hpe3par-cpg`           HPE 3Par list of CPG(s) to use for volume creation
+* `hpe3par.<backend-name>.hpe3par-target-nsp`    HPE 3Par The nsp of the backend to be used
+* `hpe3par.<backend-name>.hpe3par-debug`         HPE 3Par enable debug for WSAPI calls
+* `hpe3par.<backend-name>.replication-device`    Replication configuration. Must follow the format: backend_id:<backend_id>,san_ip:<san_ip>,san_login:<san_login>,san_password:<san_password>,...
+
+**Snapshot options**
+* `hpe3par.<backend-name>.hpe3par-snapshot-retention`     HPE 3Par snapshot retention time in hours
+* `hpe3par.<backend-name>.hpe3par-snapshot-expiration`    HPE 3Par snapshot expiration time in hours
+* `hpe3par.<backend-name>.hpe3par-cpg-snap`      HPE 3Par list of CPG(s) to use for snapshot volume creation
+
+**iSCSI options**
+* `hpe3par.<backend-name>.hpe3par-iscsi-ips`    HPE 3Par list of iSCSI addresses:[port] to use
+* `hpe3par.<backend-name>.hpe3par-iscsi-chap-enabled`     HPE 3Par enable CHAP authentication for iSCSI connections
+
+**Example:**
+```bash
+sudo snap set cinder-volume \
+  hpe3par.backend1.volume-backend-name=backend1\
+  hpe3par.backend1.san-ip=10.20.30.40 \
+  hpe3par.backend1.san-login=admin \
+  hpe3par.backend1.san-password=password \
+  hpe3par.backend1.hpe3par-api-url=https://10.20.30.40:8080/api/v1 \
+  hpe3par.backend1.hpe3par-username=edit3par \
+  hpe3par.backend1.hpe3par-password=editpassword \
+  hpe3par.backend1.hpe3par-iscsi-ips=10.20.30.40:3261,10.20.30.50 \
+  hpe3par.backend1.storage-protocol=iscsi 
+```
+
+If replication is required the above snippet will looks similar to the following:
+```bash
+sudo snap set cinder-volume \
+  hpe3par.backend1.volume-backend-name=backend1\
+  hpe3par.backend1.san-ip=10.20.30.40 \
+  hpe3par.backend1.san-login=admin \
+  hpe3par.backend1.san-password=password \
+  hpe3par.backend1.hpe3par-api-url=https://10.20.30.40:8080/api/v1 \
+  hpe3par.backend1.hpe3par-username=edit3par \
+  hpe3par.backend1.hpe3par-password=editpassword \
+  hpe3par.backend1.protocol=fc \
+  hpe3par.backend1.replication-device='backend_id:backend1,replication_mode:sync,quorum_withness_ip:10.20.30.60,san_ip:10.20.30.50,san_login:admin,san_password:password,hpe3par_api_url:http://10.20.30.50/api/v1,hpe3par_username=admin,hpe3par_password=password'
+```

--- a/cinder_volume/configuration.py
+++ b/cinder_volume/configuration.py
@@ -212,6 +212,27 @@ class DellpowerstoreConfiguration(BaseBackendConfiguration):
     protocol: str = Field(default="fc", pattern="^(iscsi|fc)$")
 
 
+class HPEthreeparConfiguration(BaseBackendConfiguration):
+    """All options recognised by the **HPE Three Par Storage** Cinder driver.
+
+    This configuration supports iSCSI and Fibre Channel protocols.
+    """
+
+    model_config = pydantic.ConfigDict(
+        extra="allow",  # Allow extra fields not defined in the model
+        alias_generator=pydantic.AliasGenerator(
+            validation_alias=to_kebab,
+            serialization_alias=pydantic.alias_generators.to_snake,
+        ),
+    )
+
+    # Core required fields
+    san_ip: pydantic.IPvAnyAddress  # HPE 3Par san controller IP
+    san_login: str  # HPE 3Par san controller username
+    san_password: str  # HPE 3Par san controller password
+    protocol: str = Field(default="fc", pattern="^(iscsi|fc)$")
+
+
 class Configuration(BaseConfiguration):
     """Holding additional configuration for the generic snap.
 
@@ -224,6 +245,7 @@ class Configuration(BaseConfiguration):
     pure: dict[str, PureConfiguration] = {}
     dellsc: dict[str, DellSCConfiguration] = {}
     dellpowerstore: dict[str, DellpowerstoreConfiguration] = {}
+    hpethreepar: dict[str, HPEthreeparConfiguration] = {}
 
     @pydantic.model_validator(mode="after")
     def validate_unique_backend_names(self):
@@ -237,6 +259,7 @@ class Configuration(BaseConfiguration):
             ("hitachi", self.hitachi),
             ("pure", self.pure),
             ("dellsc", self.dellsc),
+            ("hpe3par", self.hpethreepar),
         ]:
             for backend_key, backend in backends.items():
                 # Check for duplicate backend names across all types

--- a/cinder_volume/context.py
+++ b/cinder_volume/context.py
@@ -406,3 +406,31 @@ class DellpowerstoreBackendContext(BaseBackendContext):
             }
         )
         return context
+
+
+class HPEthreeparBackendContext(BaseBackendContext):
+    """Render a HPE 3Par backend stanza."""
+
+    _hidden_keys = ("protocol",)
+
+    def __init__(self, backend_name: str, backend_config: dict):
+        """Initialize with backend name and config."""
+        super().__init__(backend_name, backend_config)
+        self.supports_cluster = False
+
+    def context(self) -> dict:
+        """Return context for HPE 3Par backend."""
+        context = dict(super().context())
+
+        protocol = self.backend_config.get("protocol", "fc").lower()
+        driver_classes = {
+            "fc": "cinder.volume.drivers.hpe.hpe_3par_fc.HPE3PARFCDriver",
+            "iscsi": "cinder.volume.drivers.hpe.hpe_3par_iscsi.HPE3PARISCSIDriver",
+        }
+
+        context.update(
+            {
+                "volume_driver": driver_classes[protocol],
+            }
+        )
+        return context

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -57,6 +57,7 @@ parts:
   openstack:
     plugin: nil
     stage-packages:
+      - python3-3parclient
       - python3-cinder
       - cinder-volume
       - sysfsutils

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -152,3 +152,247 @@ class TestDellSCConfiguration:
         )
         assert str(config.san_ip) == "10.0.0.10"
         assert config.dell_sc_ssn == 64702
+
+
+class TestHPEthreeparConfiguration:
+    """Test the HPEthreeparConfiguration class."""
+
+    def test_hpe3par_accepts_valid_configuration(self):
+        """Test valid HPE3Par backend configuration."""
+        config = configuration.HPEthreeparConfiguration(
+            **{
+                "volume-backend-name": "hpe3par01",
+                "san-ip": "10.0.0.10",
+                "san-login": "admin",
+                "san-password": "secret",
+                "protocol": "fc",
+                "hpe3par-api-url": "https://10.0.0.10/api/v1",
+                "hpe3par-username": "edituser",
+                "hpe3par-password": "editpwd",
+            }
+        )
+        assert str(config.san_ip) == "10.0.0.10"
+        assert config.hpe3par_api_url == "https://10.0.0.10/api/v1"
+        assert config.hpe3par_username == "edituser"
+
+    def test_hpe3par_requires_san_ip(self):
+        """Test san-ip is required for HPE3Par backends."""
+        with pytest.raises(pydantic.ValidationError):
+            configuration.HPEthreeparConfiguration(
+                **{
+                    "volume-backend-name": "hpe3par01",
+                    "san-login": "admin",
+                    "san-password": "secret",
+                }
+            )
+
+    def test_hpe3par_requires_san_login(self):
+        """Test san-login is required for HPE3Par backends."""
+        with pytest.raises(pydantic.ValidationError):
+            configuration.HPEthreeparConfiguration(
+                **{
+                    "volume-backend-name": "hpe3par01",
+                    "san-ip": "10.0.0.10",
+                    "san-password": "secret",
+                }
+            )
+
+    def test_hpe3par_requires_san_password(self):
+        """Test san-password is required for HPE3Par backends."""
+        with pytest.raises(pydantic.ValidationError):
+            configuration.HPEthreeparConfiguration(
+                **{
+                    "volume-backend-name": "hpe3par01",
+                    "san-ip": "10.0.0.10",
+                    "san-login": "admin",
+                }
+            )
+
+    def test_hpe3par_requires_volume_backend_name(self):
+        """Test volume-backend-name is required for HPE3Par backends."""
+        with pytest.raises(pydantic.ValidationError):
+            configuration.HPEthreeparConfiguration(
+                **{
+                    "san-ip": "10.0.0.10",
+                    "san-login": "admin",
+                    "san-password": "secret",
+                }
+            )
+
+    def test_hpe3par_rejects_invalid_san_ip(self):
+        """Test that an invalid IP address is rejected."""
+        with pytest.raises(pydantic.ValidationError):
+            configuration.HPEthreeparConfiguration(
+                **{
+                    "volume-backend-name": "hpe3par01",
+                    "san-ip": "not-an-ip",
+                    "san-login": "admin",
+                    "san-password": "secret",
+                }
+            )
+
+    def test_hpe3par_rejects_invalid_protocol(self):
+        """Test that an invalid protocol value is rejected."""
+        with pytest.raises(pydantic.ValidationError):
+            configuration.HPEthreeparConfiguration(
+                **{
+                    "volume-backend-name": "hpe3par01",
+                    "san-ip": "10.0.0.10",
+                    "san-login": "admin",
+                    "san-password": "secret",
+                    "protocol": "nvme",
+                }
+            )
+
+    @pytest.mark.parametrize("protocol", ["fc", "iscsi"])
+    def test_hpe3par_accepts_valid_protocols(self, protocol):
+        """Test that fc and iscsi protocols are accepted."""
+        config = configuration.HPEthreeparConfiguration(
+            **{
+                "volume-backend-name": "hpe3par01",
+                "san-ip": "10.0.0.10",
+                "san-login": "admin",
+                "san-password": "secret",
+                "protocol": protocol,
+            }
+        )
+        assert config.protocol == protocol
+
+    def test_hpe3par_protocol_defaults_to_fc(self):
+        """Test that protocol defaults to fc when not specified."""
+        config = configuration.HPEthreeparConfiguration(
+            **{
+                "volume-backend-name": "hpe3par01",
+                "san-ip": "10.0.0.10",
+                "san-login": "admin",
+                "san-password": "secret",
+            }
+        )
+        assert config.protocol == "fc"
+
+    @pytest.mark.parametrize(
+        "kebab_key,snake_attr",
+        [
+            ("hpe3par-debug", "hpe3par_debug"),
+            ("hpe3par-api-url", "hpe3par_api_url"),
+            ("hpe3par-username", "hpe3par_username"),
+            ("hpe3par-password", "hpe3par_password"),
+            ("hpe3par-cpg", "hpe3par_cpg"),
+            ("hpe3par-target-nsp", "hpe3par_target_nsp"),
+            ("hpe3par-snapshot-retention", "hpe3par_snapshot_retention"),
+            ("hpe3par-snapshot-expiration", "hpe3par_snapshot_expiration"),
+            ("hpe3par-cpg-snap", "hpe3par_cpg_snap"),
+            ("hpe3par-iscsi-ips", "hpe3par_iscsi_ips"),
+            ("hpe3par-iscsi-chap-enabled", "hpe3par_iscsi_chap_enabled"),
+            ("replication-device", "replication_device"),
+        ],
+    )
+    def test_hpe3par_extra_field_validation_alias(self, kebab_key, snake_attr):
+        """Test that extra fields in kebab-case are validated into snake_case."""
+        config = configuration.HPEthreeparConfiguration(
+            **{
+                "volume-backend-name": "hpe3par01",
+                "san-ip": "10.0.0.10",
+                "san-login": "admin",
+                "san-password": "secret",
+                kebab_key: "test_value",
+            }
+        )
+        assert getattr(config, snake_attr) == "test_value"
+
+    @pytest.mark.parametrize(
+        "kebab_key,snake_key",
+        [
+            ("hpe3par-debug", "hpe3par_debug"),
+            ("hpe3par-api-url", "hpe3par_api_url"),
+            ("hpe3par-username", "hpe3par_username"),
+            ("hpe3par-password", "hpe3par_password"),
+            ("hpe3par-cpg", "hpe3par_cpg"),
+            ("hpe3par-target-nsp", "hpe3par_target_nsp"),
+            ("replication-device", "replication_device"),
+        ],
+    )
+    def test_hpe3par_extra_field_serialization_alias(self, kebab_key, snake_key):
+        """Test that extra fields are serialized to snake_case with model_dump."""
+        config = configuration.HPEthreeparConfiguration(
+            **{
+                "volume-backend-name": "hpe3par01",
+                "san-ip": "10.0.0.10",
+                "san-login": "admin",
+                "san-password": "secret",
+                kebab_key: "test_value",
+            }
+        )
+        data = config.model_dump(by_alias=True)
+        assert snake_key in data
+        assert data[snake_key] == "test_value"
+
+    def test_hpe3par_defined_fields_serialized_to_snake_case(self):
+        """Test that defined fields are serialized to snake_case."""
+        config = configuration.HPEthreeparConfiguration(
+            **{
+                "volume-backend-name": "hpe3par01",
+                "san-ip": "10.0.0.10",
+                "san-login": "admin",
+                "san-password": "secret",
+                "protocol": "iscsi",
+            }
+        )
+        data = config.model_dump(by_alias=True)
+        assert "san_ip" in data
+        assert "san_login" in data
+        assert "san_password" in data
+        assert "protocol" in data
+        assert "volume_backend_name" in data
+        assert data["san_login"] == "admin"
+        assert data["san_password"] == "secret"
+        assert data["protocol"] == "iscsi"
+        assert data["volume_backend_name"] == "hpe3par01"
+
+    def test_hpe3par_full_config_serialization(self):
+        """Test serialization of a full HPE3Par config with mixed fields."""
+        config = configuration.HPEthreeparConfiguration(
+            **{
+                "volume-backend-name": "hpe3par01",
+                "san-ip": "10.0.0.10",
+                "san-login": "admin",
+                "san-password": "secret",
+                "protocol": "fc",
+                "hpe3par-api-url": "https://10.0.0.10/api/v1",
+                "hpe3par-username": "edituser",
+                "hpe3par-password": "editpwd",
+                "hpe3par-debug": "true",
+                "hpe3par-cpg": "OpenStack",
+            }
+        )
+        data = config.model_dump(by_alias=True)
+        # Defined fields serialized to snake_case
+        assert data["san_login"] == "admin"
+        assert data["protocol"] == "fc"
+        # Extra fields serialized to snake_case
+        assert data["hpe3par_api_url"] == "https://10.0.0.10/api/v1"
+        assert data["hpe3par_username"] == "edituser"
+        assert data["hpe3par_password"] == "editpwd"
+        assert data["hpe3par_debug"] == "true"
+        assert data["hpe3par_cpg"] == "OpenStack"
+
+    def test_hpe3par_multiple_extra_fields(self):
+        """Test that multiple extra fields are all converted correctly."""
+        config = configuration.HPEthreeparConfiguration(
+            **{
+                "volume-backend-name": "hpe3par01",
+                "san-ip": "10.0.0.10",
+                "san-login": "admin",
+                "san-password": "secret",
+                "protocol": "iscsi",
+                "hpe3par-debug": "true",
+                "hpe3par-cpg": "OpenStack",
+                "hpe3par-iscsi-ips": "10.0.0.11,10.0.0.12",
+                "hpe3par-iscsi-chap-enabled": "true",
+            }
+        )
+        assert config.hpe3par_debug == "true"
+        assert config.hpe3par_cpg == "OpenStack"
+        assert config.protocol == "iscsi"
+        assert config.hpe3par_iscsi_ips == "10.0.0.11,10.0.0.12"
+        assert config.hpe3par_iscsi_chap_enabled == "true"


### PR DESCRIPTION
This PR proposes the addition of the HPE 3Par cinder backend support.
This backend requires the additional python3-3parclient package, as per [the driver guide](https://docs.openstack.org/cinder/latest/configuration/block-storage/drivers/hpe-3par-driver.html#enable-the-hpe-3par-fibre-channel-and-iscsi-drivers).

Needed-by:
- https://review.opendev.org/c/openstack/sunbeam-charms/+/978778
- https://github.com/canonical/snap-openstack/pull/703