### PR TITLE
feat: include storage array plugs

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -10,6 +10,9 @@ description: |
 grade: stable
 confinement: strict
 
+assumes:
+- snapd2.73
+
 environment:
   LC_ALL: C
   PATH: $SNAP/usr/sbin:$SNAP/usr/bin:$SNAP/sbin:$SNAP/bin:$SNAP/usr/local/bin:$SNAP/usr/local/sbin:$PATH
@@ -40,12 +43,10 @@ apps:
       - system-observe
       - hardware-observe
       - log-observe
-      # Commented until these plugs are available in snapd
-      # - nvme-control
-      # - iscsi-initiator
-      # - dm-multipath
-      # Needed by multipath, will request it at the same times as multipath-control
-      # - process-control
+      - process-control
+      - nvme-control
+      - iscsi-initiator
+      - dm-multipath
 
 parts:
   openstack:


### PR DESCRIPTION
These plugs are only available on snapd2.73+


(cherry picked from commit ed8626726d8e68ce95e4a645429f62b9eec76073)