### PR TITLE
feat: configure internal endpoints and region for peer services

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ See "Configuration Reference" for full details.
 
 * `cinder.project-id` Project ID for Cinder service
 * `cinder.user-id` User ID for Cinder service
+* `cinder.region-name` (optional) Region name to use for peer OpenStack service lookups
 * `cinder.image-volume-cache-enabled` (false) Enable image volume cache
 * `cinder.image-volume-cache-max-size-gb` (0) Max size of image volume cache in GB
 * `cinder.image-volume-cache-max-count` (0) Max number of images in cache

--- a/cinder_volume/configuration.py
+++ b/cinder_volume/configuration.py
@@ -49,6 +49,7 @@ class CinderConfiguration(ParentConfig):
 
     project_id: str
     user_id: str
+    region_name: str | None = None
     image_volume_cache_enabled: bool = False
     image_volume_cache_max_size_gb: int = 0
     image_volume_cache_max_count: int = 0

--- a/cinder_volume/templates/cinder.conf.j2
+++ b/cinder_volume/templates/cinder.conf.j2
@@ -23,14 +23,34 @@ enabled_backends = {{ cinder_backends.enabled_backends }}
 {% if ca and ca.bundle %}
 glance_ca_certificates_file = {{ snap_paths.common }}/etc/ssl/certs/receive-ca-bundle.pem
 glance_api_insecure = false
+{% endif %}
 
 [nova]
+interface = internal
+{% if cinder.region_name %}
+region_name = {{ cinder.region_name }}
+{% endif %}
+{% if ca and ca.bundle %}
 cafile = {{ snap_paths.common }}/etc/ssl/certs/receive-ca-bundle.pem
+{% endif %}
 
 [barbican]
+interface = internal
+{% if cinder.region_name %}
+region_name = {{ cinder.region_name }}
+{% endif %}
+{% if ca and ca.bundle %}
 cafile = {{ snap_paths.common }}/etc/ssl/certs/receive-ca-bundle.pem
+{% endif %}
 
 [glance]
+service_type = image
+service_name = glance
+valid_interfaces = internal
+{% if cinder.region_name %}
+region_name = {{ cinder.region_name }}
+{% endif %}
+{% if ca and ca.bundle %}
 cafile = {{ snap_paths.common }}/etc/ssl/certs/receive-ca-bundle.pem
 {% endif %}
 

--- a/tests/test_cinder_volume_runtime.py
+++ b/tests/test_cinder_volume_runtime.py
@@ -60,6 +60,7 @@ class TestGenericCinderVolume:
             cinder={
                 "project_id": "project-id",
                 "user_id": "user-id",
+                "region_name": "RegionOne",
                 "cluster": None,
                 "cluster_ok": True,
                 "default_volume_type": None,
@@ -81,25 +82,24 @@ class TestGenericCinderVolume:
             in rendered
         )
         assert "glance_api_insecure = false" in rendered
+        assert "\n[nova]\n" in rendered
+        assert "\n[barbican]\n" in rendered
+        assert "\n[glance]\n" in rendered
+        assert rendered.count("interface = internal") == 2
+        assert "valid_interfaces = internal" in rendered
+        assert "service_type = image" in rendered
+        assert "service_name = glance" in rendered
+        assert rendered.count("region_name = RegionOne") == 3
         assert (
-            "\n[nova]\n"
-            "cafile = /var/snap/cinder-volume/common/etc/ssl/certs/"
-            "receive-ca-bundle.pem" in rendered
-        )
-        assert (
-            "\n[barbican]\n"
-            "cafile = /var/snap/cinder-volume/common/etc/ssl/certs/"
-            "receive-ca-bundle.pem" in rendered
-        )
-        assert (
-            "\n[glance]\n"
-            "cafile = /var/snap/cinder-volume/common/etc/ssl/certs/"
-            "receive-ca-bundle.pem" in rendered
+            rendered.count(
+                "cafile = /var/snap/cinder-volume/common/etc/ssl/certs/receive-ca-bundle.pem"
+            )
+            == 3
         )
         assert "enabled_backends = ceph\ncafile =" not in rendered
 
-    def test_cinder_conf_skips_ca_sections_when_ca_bundle_missing(self):
-        """The template should omit service-specific CA settings without a CA bundle."""
+    def test_cinder_conf_skips_ca_settings_when_ca_bundle_missing(self):
+        """The template should omit CA settings but keep sections when no CA bundle."""
         env = jinja2.Environment(
             loader=jinja2.FileSystemLoader(
                 Path(cinder_volume.__file__).parent / "templates"
@@ -114,6 +114,7 @@ class TestGenericCinderVolume:
             cinder={
                 "project_id": "project-id",
                 "user_id": "user-id",
+                "region_name": None,
                 "cluster": None,
                 "cluster_ok": True,
                 "default_volume_type": None,
@@ -127,9 +128,50 @@ class TestGenericCinderVolume:
 
         assert "glance_ca_certificates_file =" not in rendered
         assert "glance_api_insecure = false" not in rendered
-        assert "\n[nova]\n" not in rendered
-        assert "\n[barbican]\n" not in rendered
-        assert "\n[glance]\n" not in rendered
+        assert "cafile =" not in rendered
+        assert "region_name =" not in rendered
+        assert "\n[nova]\n" in rendered
+        assert "\n[barbican]\n" in rendered
+        assert "\n[glance]\n" in rendered
+
+    def test_cinder_conf_renders_internal_client_sections_when_region_is_set(self):
+        """Render peer sections with internal endpoints when region exists."""
+        env = jinja2.Environment(
+            loader=jinja2.FileSystemLoader(
+                Path(cinder_volume.__file__).parent / "templates"
+            )
+        )
+
+        rendered = env.get_template("cinder.conf.j2").render(
+            snap_paths={"common": "/var/snap/cinder-volume/common"},
+            settings={"debug": False, "enable_telemetry_notifications": False},
+            rabbitmq={"url": "amqp://guest:guest@localhost:5672/"},
+            database={"url": "mysql://cinder:secret@db/cinder"},
+            cinder={
+                "project_id": "project-id",
+                "user_id": "user-id",
+                "region_name": "RegionOne",
+                "cluster": None,
+                "cluster_ok": True,
+                "default_volume_type": None,
+                "image_volume_cache_enabled": False,
+                "image_volume_cache_max_size_gb": 0,
+                "image_volume_cache_max_count": 0,
+            },
+            ca={"bundle": None},
+            cinder_backends={"enabled_backends": "ceph", "cluster_ok": True},
+        )
+
+        assert "glance_ca_certificates_file =" not in rendered
+        assert "\n[nova]\n" in rendered
+        assert "\n[barbican]\n" in rendered
+        assert "\n[glance]\n" in rendered
+        assert rendered.count("interface = internal") == 2
+        assert "valid_interfaces = internal" in rendered
+        assert "service_type = image" in rendered
+        assert "service_name = glance" in rendered
+        assert rendered.count("region_name = RegionOne") == 3
+        assert "cafile = /var/snap/cinder-volume/common/etc/ssl/certs/" not in rendered
 
     def test_cinder_conf_renders_cluster_when_supported_and_set(self):
         """Cluster should be rendered when all enabled backends support it."""
@@ -147,6 +189,7 @@ class TestGenericCinderVolume:
             cinder={
                 "project_id": "project-id",
                 "user_id": "user-id",
+                "region_name": None,
                 "cluster": "cinder-cluster-a",
                 "default_volume_type": None,
                 "image_volume_cache_enabled": False,
@@ -175,6 +218,7 @@ class TestGenericCinderVolume:
             cinder={
                 "project_id": "project-id",
                 "user_id": "user-id",
+                "region_name": None,
                 "cluster": "cinder-cluster-a",
                 "default_volume_type": None,
                 "image_volume_cache_enabled": False,

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -92,6 +92,7 @@ class TestCinderConfiguration:
             **{
                 "project-id": "test-project",
                 "user-id": "test-user",
+                "region-name": "RegionOne",
                 "image-volume-cache-enabled": True,
                 "image-volume-cache-max-size-gb": 100,
                 "image-volume-cache-max-count": 10,
@@ -99,6 +100,7 @@ class TestCinderConfiguration:
         )
         assert config.project_id == "test-project"
         assert config.user_id == "test-user"
+        assert config.region_name == "RegionOne"
         assert config.image_volume_cache_enabled is True
         assert config.image_volume_cache_max_size_gb == 100
         assert config.image_volume_cache_max_count == 10
@@ -109,6 +111,7 @@ class TestCinderConfiguration:
             **{
                 "project-id": "test-project",
                 "user-id": "test-user",
+                "region-name": "RegionOne",
                 "image-volume-cache-enabled": True,
                 "image-volume-cache-max-size-gb": 100,
                 "image-volume-cache-max-count": 10,
@@ -116,6 +119,7 @@ class TestCinderConfiguration:
         )
         assert config.project_id == "test-project"
         assert config.user_id == "test-user"
+        assert config.region_name == "RegionOne"
 
 
 class TestDellSCConfiguration:


### PR DESCRIPTION
Add optional region-name setting to CinderConfiguration. Configure nova, barbican, and glance sections with internal endpoint settings, and conditionally render region_name and cafile within each section.