### PR TITLE
snap: use architecture triplet for Ceph library path

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -37,7 +37,7 @@ apps:
     environment:
       # Standard library components must have priority in module name resolution: https://storyboard.openstack.org/#!/story/2007806
       PYTHONPATH: $SNAP/usr/lib/python3/dist-packages:$SNAP/lib/python3.14:$SNAP/lib/python3.14/site-packages
-      LD_LIBRARY_PATH: $LD_LIBRARY_PATH:$SNAP/usr/lib/x86_64-linux-gnu:$SNAP/usr/lib/x86_64-linux-gnu/ceph
+      LD_LIBRARY_PATH: $LD_LIBRARY_PATH:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/ceph
     command: bin/cinder_volume
     daemon: simple
     plugs:


### PR DESCRIPTION
Use Snapcraft's build-for architecture triplet in the cinder-volume runtime LD_LIBRARY_PATH instead of hard-coding x86_64-linux-gnu.

The Ceph Python modules load librados/librbd support libraries from the architecture-specific Ceph library directory. Hard-coding the amd64 path prevents rados and rbd from importing on s390x.

This keeps the existing amd64 path unchanged while allowing s390x builds to resolve libraries from s390x-linux-gnu.

Assisted-by: Codex <codex@openai.com>