### PR TITLE
Add identity credentials for nova auth in cinder.conf

### DIFF
--- a/cinder_volume/configuration.py
+++ b/cinder_volume/configuration.py
@@ -57,6 +57,30 @@ class CinderConfiguration(ParentConfig):
     cluster: str | None = None
 
 
+class IdentityConfiguration(ParentConfig):
+    """Keystone credentials for cinder to authenticate to other services."""
+
+    auth_url: str | None = None
+    username: str | None = None
+    password: str | None = None
+    project_name: str | None = None
+    user_domain_name: str | None = None
+    project_domain_name: str | None = None
+
+    @model_validator(mode="after")
+    def _all_or_none(self) -> "IdentityConfiguration":
+        """Require the credentials to be set together."""
+        values = self.model_dump()
+        set_keys = [k for k, v in values.items() if v is not None]
+        if set_keys and len(set_keys) != len(values):
+            missing = sorted(set(values) - set(set_keys))
+            raise ValueError(
+                "identity credentials must be set together; missing: "
+                + ", ".join(missing)
+            )
+        return self
+
+
 class Settings(ParentConfig):
     """General settings for the snap."""
 
@@ -90,6 +114,7 @@ class BaseConfiguration(ParentConfig):
 
     settings: Settings = Settings()
     ca: CAConfiguration = CAConfiguration()
+    identity: IdentityConfiguration = IdentityConfiguration()
     database: DatabaseConfiguration
     rabbitmq: RabbitMQConfiguration
     cinder: CinderConfiguration

--- a/cinder_volume/templates/cinder.conf.j2
+++ b/cinder_volume/templates/cinder.conf.j2
@@ -28,6 +28,15 @@ glance_api_insecure = false
 
 [nova]
 interface = internal
+{% if identity is defined and identity.auth_url %}
+auth_type = password
+auth_url = {{ identity.auth_url }}
+username = {{ identity.username }}
+password = {{ identity.password }}
+project_name = {{ identity.project_name }}
+user_domain_name = {{ identity.user_domain_name }}
+project_domain_name = {{ identity.project_domain_name }}
+{% endif %}
 {% if cinder.region_name %}
 region_name = {{ cinder.region_name }}
 {% endif %}

--- a/tests/test_cinder_volume_runtime.py
+++ b/tests/test_cinder_volume_runtime.py
@@ -140,6 +140,95 @@ class TestGenericCinderVolume:
         assert cafile in barbican_section
         assert "enabled_backends = ceph\ncafile =" not in rendered
 
+    def test_cinder_conf_renders_nova_auth_when_identity_set(self):
+        """The [nova] section should carry auth options when identity is set."""
+        env = jinja2.Environment(
+            loader=jinja2.FileSystemLoader(
+                Path(cinder_volume.__file__).parent / "templates"
+            )
+        )
+
+        rendered = env.get_template("cinder.conf.j2").render(
+            snap_paths={"common": "/var/snap/cinder-volume/common"},
+            settings={"debug": False, "enable_telemetry_notifications": False},
+            rabbitmq={"url": "amqp://guest:guest@localhost:5672/"},
+            database={"url": "mysql://cinder:secret@db/cinder"},
+            cinder={
+                "project_id": "project-id",
+                "user_id": "user-id",
+                "region_name": "RegionOne",
+                "cluster": None,
+                "cluster_ok": True,
+                "default_volume_type": None,
+                "image_volume_cache_enabled": False,
+                "image_volume_cache_max_size_gb": 0,
+                "image_volume_cache_max_count": 0,
+            },
+            identity={
+                "auth_url": "http://keystone.internal/openstack-keystone/v3",
+                "username": "cinder-volume",
+                "password": "secret",
+                "project_name": "services",
+                "user_domain_name": "service_domain",
+                "project_domain_name": "service_domain",
+            },
+            ca={"bundle": None},
+            cinder_backends={"enabled_backends": "ceph", "cluster_ok": True},
+        )
+
+        nova_section = _get_section(rendered, "nova")
+        assert "interface = internal" in nova_section
+        assert "auth_type = password" in nova_section
+        assert (
+            "auth_url = http://keystone.internal/openstack-keystone/v3" in nova_section
+        )
+        assert "username = cinder-volume" in nova_section
+        assert "password = secret" in nova_section
+        assert "project_name = services" in nova_section
+        assert "user_domain_name = service_domain" in nova_section
+        assert "project_domain_name = service_domain" in nova_section
+
+    def test_cinder_conf_skips_nova_auth_when_identity_unset(self):
+        """The [nova] section should have no auth options without identity."""
+        env = jinja2.Environment(
+            loader=jinja2.FileSystemLoader(
+                Path(cinder_volume.__file__).parent / "templates"
+            )
+        )
+
+        rendered = env.get_template("cinder.conf.j2").render(
+            snap_paths={"common": "/var/snap/cinder-volume/common"},
+            settings={"debug": False, "enable_telemetry_notifications": False},
+            rabbitmq={"url": "amqp://guest:guest@localhost:5672/"},
+            database={"url": "mysql://cinder:secret@db/cinder"},
+            cinder={
+                "project_id": "project-id",
+                "user_id": "user-id",
+                "region_name": "RegionOne",
+                "cluster": None,
+                "cluster_ok": True,
+                "default_volume_type": None,
+                "image_volume_cache_enabled": False,
+                "image_volume_cache_max_size_gb": 0,
+                "image_volume_cache_max_count": 0,
+            },
+            identity={
+                "auth_url": None,
+                "username": None,
+                "password": None,
+                "project_name": None,
+                "user_domain_name": None,
+                "project_domain_name": None,
+            },
+            ca={"bundle": None},
+            cinder_backends={"enabled_backends": "ceph", "cluster_ok": True},
+        )
+
+        nova_section = _get_section(rendered, "nova")
+        assert "interface = internal" in nova_section
+        assert "auth_type" not in nova_section
+        assert "auth_url" not in nova_section
+
     def test_cinder_conf_skips_ca_settings_when_ca_bundle_missing(self):
         """The template should omit CA settings but keep sections when no CA bundle."""
         env = jinja2.Environment(

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -83,6 +83,50 @@ class TestRabbitMQConfiguration:
         assert data["url"] == "amqp://localhost"
 
 
+class TestIdentityConfiguration:
+    """Test the IdentityConfiguration class."""
+
+    def test_identity_config_creation(self):
+        """Test creating an IdentityConfiguration instance."""
+        config = configuration.IdentityConfiguration(
+            **{
+                "auth-url": "http://keystone.internal/openstack-keystone/v3",
+                "username": "cinder-volume",
+                "password": "secret",
+                "project-name": "services",
+                "user-domain-name": "service_domain",
+                "project-domain-name": "service_domain",
+            }
+        )
+        assert config.auth_url == "http://keystone.internal/openstack-keystone/v3"
+        assert config.username == "cinder-volume"
+        assert config.password == "secret"
+        assert config.project_name == "services"
+        assert config.user_domain_name == "service_domain"
+        assert config.project_domain_name == "service_domain"
+
+    def test_identity_config_rejects_partial_credentials(self):
+        """Setting only some identity fields must fail validation."""
+        with pytest.raises(pydantic.ValidationError):
+            configuration.IdentityConfiguration(
+                **{
+                    "auth-url": "http://keystone.internal/openstack-keystone/v3",
+                    "username": "cinder-volume",
+                    "password": "secret",
+                }
+            )
+
+    def test_identity_config_defaults_to_none(self):
+        """All identity fields are optional."""
+        config = configuration.IdentityConfiguration()
+        assert config.auth_url is None
+        assert config.username is None
+        assert config.password is None
+        assert config.project_name is None
+        assert config.user_domain_name is None
+        assert config.project_domain_name is None
+
+
 class TestCinderConfiguration:
     """Test the CinderConfiguration class."""
 


### PR DESCRIPTION
## Summary

Add an 'identity' snap configuration namespace (auth-url, username, password, project-name, user-domain-name, project-domain-name), and render password auth into [nova] when the credentials are set. All new fields default to unset and the template output is unchanged when they are absent.

## Problem/Root Cause

Every online volume extend leaves the guest at the old size. cinder-volume resizes the backend volume, then fails to notify nova:

```
ERROR cinder.compute.nova Failed to notify nova on events: [{'name': 'volume-extended', ...}]
keystoneauth1.exceptions.http.BadRequest: Expecting to find domain in project. (HTTP 400)
```

cinder's nova client loads a keystone session from the `[nova]` section of cinder.conf. The snap renders that section with only `interface = internal` and has no configuration surface to accept service credentials, so keystoneauth has no auth plugin and the request is rejected.

## Compatibility

Fields are optional with `None` defaults, so that a snap refresh before the charm fix is applied does nothing (and does not cause any error). The accompanying [sunbeam-charms change](https://review.opendev.org/c/openstack/sunbeam-charms/+/996978) populates the keys from the charm's existing `identity-credentials` relation.

Closes: https://bugs.launchpad.net/snap-cinder-volume/+bug/2156802