### PR TITLE
fix: ensure backend tls materials correctly templated

### DIFF
--- a/cinder_volume/cinder_volume.py
+++ b/cinder_volume/cinder_volume.py
@@ -8,8 +8,12 @@ for managing Cinder volume services within a snap environment.
 """
 
 import abc
+import dataclasses
 import inspect
 import logging
+import os
+import stat
+import tempfile
 import typing
 from pathlib import Path
 
@@ -24,6 +28,21 @@ ETC_SSL_CERTS = Path("etc/ssl/certs")
 
 
 CONF = typing.TypeVar("CONF", bound=configuration.BaseConfiguration)
+ManagedFile = template.Template | context.BackendTLSMaterial
+ManagedOutput = ManagedFile | Path
+PreparedFile = tuple[ManagedFile, bytes | None]
+
+
+@dataclasses.dataclass(frozen=True)
+class OriginalFile:
+    """Restorable state of one managed path before a transaction."""
+
+    kind: typing.Literal["absent", "regular", "symlink"]
+    content: bytes | str | None = None
+    mode: int | None = None
+
+
+PendingFile = tuple[ManagedFile, Path, Path | None, OriginalFile]
 
 
 class CinderVolume(typing.Generic[CONF], abc.ABC):
@@ -56,41 +75,36 @@ class CinderVolume(typing.Generic[CONF], abc.ABC):
 
     def configure(self, snap: Snap) -> None:
         """Configure the Cinder volume service."""
-        # Always clear existing backend configuration files first
-        # This ensures cleanup even when no backends are configured
-        self._clear_backend_configs(snap)
+        backend_contexts = self.backend_contexts(snap)
 
-        try:
-            backend_contexts = self.backend_contexts(snap)
-        except error.CinderError as e:
-            # If no backends are configured, just clear configs and exit
-            if "At least one backend must be enabled" in str(e):
-                logging.info("No backends configured, cleared all backend configs")
-                return
-            # Re-raise other configuration errors
-            raise
-
+        prepared = self._prepare_configuration_files(snap, backend_contexts)
         self.setup_dirs(snap, backend_contexts)
-        modified = self.template(snap)
-        backend_tpls = []
+        modified: list[ManagedOutput] = [
+            *self._write_configuration_files(snap, prepared)
+        ]
+        backend_tpls: list[ManagedOutput] = []
         for backend_context in backend_contexts.contexts.values():
             backend_tpls.extend(backend_context.template_files())
+            backend_tpls.extend(backend_context.tls_materials)
             backend_context.setup(snap)
+        pruned = self._prune_stale_backend_configs(snap, backend_contexts)
+        modified.extend(pruned)
+        backend_tpls.extend(pruned)
         self.start_services(snap, modified, backend_tpls)
 
     def start_services(
         self,
         snap: Snap,
-        modified_tpl: typing.Sequence[template.Template],
-        backend_tpls: typing.Sequence[template.Template],
+        modified_tpl: typing.Sequence[ManagedOutput],
+        backend_tpls: typing.Sequence[ManagedOutput],
     ) -> None:
         """Start the Cinder volume services."""
         modified_files: set[Path] = set()
         for tpl in modified_tpl:
-            modified_files.add(tpl.output_path())
+            modified_files.add(tpl if isinstance(tpl, Path) else tpl.output_path())
         backend_files: set[Path] = set()
         for tpl in backend_tpls:
-            backend_files.add(tpl.output_path())
+            backend_files.add(tpl if isinstance(tpl, Path) else tpl.output_path())
         snap_services = snap.services.list()
         for service in services.services():
             snap_service = snap_services.get(service.name)
@@ -207,50 +221,334 @@ class CinderVolume(typing.Generic[CONF], abc.ABC):
         self,
         snap: Snap,
         env: jinja2.Environment,
-        template: template.Template,
+        tpl: template.Template,
         context: typing.Mapping[str, typing.Mapping[str, str]],
     ) -> bool:
-        file_name = template.filename
-        dest_dir: Path = getattr(snap.paths, template.location) / template.dest
-        dest_dir.mkdir(parents=True, exist_ok=True)
-        dest_file = dest_dir / file_name.removesuffix(".j2")
+        """Render and atomically write one template."""
+        content = self._render_template(env, tpl, context)
+        return self._write_managed_file(snap, tpl, content)
 
-        original_hash = None
-        if dest_file.exists():
-            original_hash = hash(dest_file.read_text())
+    def _render_template(
+        self,
+        env: jinja2.Environment,
+        tpl: template.Template,
+        context: typing.Mapping[str, typing.Mapping[str, str]],
+    ) -> bytes | None:
+        """Render a template in memory without changing the filesystem."""
+        if tpl.conditionals and not all(cond(context) for cond in tpl.conditionals):
+            logging.debug(
+                "Skipping template %s due to unmet conditionals", tpl.filename
+            )
+            return None
 
-        if template.conditionals:
-            if not all(cond(context) for cond in template.conditionals):
-                logging.debug(
-                    "Skipping template %s due to unmet conditionals", template.filename
-                )
-                if dest_file.exists():
-                    logging.debug("Removing existing file %s", dest_file)
-                    dest_file.unlink()
-                return False
-
-        tpl = None
-        template_file = template.template()
+        template_file = tpl.template()
         try:
-            tpl = env.get_template(template_file)
+            jinja_template = env.get_template(template_file)
         except jinja2.exceptions.TemplateNotFound:
             logging.debug("Template %s not found, trying with .j2", template_file)
-            tpl = env.get_template(template_file + ".j2")
+            jinja_template = env.get_template(template_file + ".j2")
 
-        rendered = tpl.render(**context)
+        rendered = jinja_template.render(**context)
         if len(rendered) > 0 and rendered[-1] != "\n":
-            # ensure trailing new line
             rendered += "\n"
+        return rendered.encode("utf-8")
 
-        new_hash = hash(rendered)
+    def _managed_file_destination(self, snap: Snap, managed_file: ManagedFile) -> Path:
+        """Resolve a managed output without allowing path traversal."""
+        output_path = managed_file.output_path()
+        if output_path.is_absolute() or ".." in output_path.parts:
+            raise ValueError(
+                f"Managed file {output_path} resolves outside its destination"
+            )
+        location = (
+            managed_file.location
+            if isinstance(managed_file, template.Template)
+            else "common"
+        )
+        return getattr(snap.paths, location) / output_path
 
-        if original_hash == new_hash:
-            logging.debug("File %s has not changed, skipping", dest_file)
-            return False
-        logging.debug("File %s has changed, writing new content", dest_file)
-        dest_file.write_text(rendered)
-        dest_file.chmod(template.mode)
+    def _write_managed_file(
+        self,
+        snap: Snap,
+        managed_file: ManagedFile,
+        content: bytes | None,
+    ) -> bool:
+        """Atomically replace or remove one prepared managed file."""
+        dest_file = self._managed_file_destination(snap, managed_file)
+        if content is None:
+            try:
+                dest_file.unlink()
+            except FileNotFoundError:
+                return False
+            return True
+
+        try:
+            existing_mode = dest_file.lstat().st_mode
+            if (
+                stat.S_ISREG(existing_mode)
+                and stat.S_IMODE(existing_mode) == managed_file.mode
+                and dest_file.read_bytes() == content
+            ):
+                logging.debug("File %s has not changed, skipping", dest_file)
+                return False
+        except FileNotFoundError:
+            pass
+
+        dest_dir = dest_file.parent
+        dest_dir.mkdir(parents=True, exist_ok=True)
+        temporary_path: Path | None = None
+        try:
+            with tempfile.NamedTemporaryFile(
+                mode="w+b",
+                dir=dest_dir,
+                prefix=f".{dest_file.name}.",
+                delete=False,
+            ) as temporary:
+                temporary_path = Path(temporary.name)
+                os.fchmod(temporary.fileno(), 0o600)
+                temporary.write(content)
+                temporary.flush()
+                os.fsync(temporary.fileno())
+                os.fchmod(temporary.fileno(), managed_file.mode)
+            os.replace(temporary_path, dest_file)
+        finally:
+            if temporary_path is not None:
+                temporary_path.unlink(missing_ok=True)
+        logging.debug("Atomically replaced managed file %s", dest_file)
         return True
+
+    def _backend_tls_material_content(
+        self,
+        backend_context: context.BaseBackendContext,
+        material: context.BackendTLSMaterial,
+    ) -> bytes | None:
+        """Return opaque TLS bytes without exposing them to Jinja."""
+        value = backend_context.backend_config.get(material.content_option)
+        if isinstance(value, pydantic.SecretStr):
+            value = value.get_secret_value()
+        return value.encode("utf-8") if value else None
+
+    def _process_backend_tls_material(
+        self,
+        snap: Snap,
+        backend_context: context.BaseBackendContext,
+        material: context.BackendTLSMaterial,
+    ) -> bool:
+        """Write one backend TLS material value without template evaluation."""
+        content = self._backend_tls_material_content(backend_context, material)
+        return self._write_managed_file(snap, material, content)
+
+    def _prepare_files(
+        self,
+        snap: Snap,
+        env: jinja2.Environment,
+        render_context: typing.MutableMapping[str, typing.Any],
+        backend_contexts: context.CinderBackendContexts,
+    ) -> list[tuple[ManagedFile, bytes | None]]:
+        """Render every desired output before allowing any filesystem change."""
+        prepared: list[tuple[ManagedFile, bytes | None]] = []
+        for tpl in self.template_files():
+            prepared.append((tpl, self._render_template(env, tpl, render_context)))
+
+        for backend_context in backend_contexts.contexts.values():
+            render_context[context.BACKEND_CTX_KEY] = backend_context.context()
+            render_context[context.CINDER_CTX_KEY] = backend_context.backend_name
+            try:
+                for tpl in backend_context.template_files():
+                    prepared.append(
+                        (tpl, self._render_template(env, tpl, render_context))
+                    )
+                for material in backend_context.tls_materials:
+                    prepared.append(
+                        (
+                            material,
+                            self._backend_tls_material_content(
+                                backend_context, material
+                            ),
+                        )
+                    )
+            finally:
+                render_context.pop(context.CINDER_CTX_KEY)
+                render_context.pop(context.BACKEND_CTX_KEY)
+
+        for managed_file, _ in prepared:
+            self._managed_file_destination(snap, managed_file)
+        self._validate_prepared_destinations(snap, prepared)
+        return prepared
+
+    def _validate_prepared_destinations(
+        self, snap: Snap, prepared: typing.Sequence[PreparedFile]
+    ) -> dict[Path, PreparedFile]:
+        """Resolve each prepared output and reject ownership collisions."""
+        destinations: dict[Path, PreparedFile] = {}
+        for managed_file, content in prepared:
+            destination = self._managed_file_destination(snap, managed_file)
+            if destination in destinations:
+                raise error.CinderError(f"duplicate managed destination: {destination}")
+            destinations[destination] = (managed_file, content)
+        return destinations
+
+    def _write_prepared_files(
+        self,
+        snap: Snap,
+        prepared: typing.Sequence[PreparedFile],
+    ) -> list[ManagedFile]:
+        """Apply prepared outputs as a rollback-capable file transaction."""
+        destinations = self._validate_prepared_destinations(snap, prepared)
+        temporary_paths: set[Path] = set()
+        try:
+            pending = self._stage_pending_files(destinations, temporary_paths)
+            self._apply_pending_files(pending, temporary_paths)
+            return [managed_file for managed_file, _, _, _ in pending]
+        finally:
+            for temporary_path in temporary_paths:
+                temporary_path.unlink(missing_ok=True)
+
+    def _stage_pending_files(
+        self,
+        destinations: typing.Mapping[Path, PreparedFile],
+        temporary_paths: set[Path],
+    ) -> list[PendingFile]:
+        """Stage every changed replacement before active files are touched."""
+        pending: list[PendingFile] = []
+        for destination, (managed_file, content) in destinations.items():
+            original = self._snapshot_active_file(destination)
+            if not self._managed_file_changed(original, managed_file, content):
+                continue
+            staged = None
+            if content is not None:
+                staged = self._stage_managed_file(
+                    destination, content, managed_file.mode
+                )
+                temporary_paths.add(staged)
+            pending.append((managed_file, destination, staged, original))
+        return pending
+
+    def _apply_pending_files(
+        self, pending: typing.Sequence[PendingFile], temporary_paths: set[Path]
+    ) -> None:
+        """Replace staged files and restore active files after a failure."""
+        replacements = [item for item in pending if item[2] is not None]
+        deletions = [item for item in pending if item[2] is None]
+        applied: list[tuple[Path, OriginalFile]] = []
+        try:
+            for _, destination, staged, original in [*replacements, *deletions]:
+                if staged is not None:
+                    os.replace(staged, destination)
+                    temporary_paths.discard(staged)
+                else:
+                    destination.unlink()
+                applied.append((destination, original))
+        except Exception:
+            self._rollback_applied_files(applied, temporary_paths)
+            raise
+
+    def _rollback_applied_files(
+        self,
+        applied: typing.Sequence[tuple[Path, OriginalFile]],
+        temporary_paths: set[Path],
+    ) -> None:
+        """Restore all active paths already changed by a failed transaction."""
+        rollback_errors: list[OSError] = []
+        for destination, original in reversed(applied):
+            try:
+                self._restore_original_file(destination, original, temporary_paths)
+            except OSError as rollback_error:
+                rollback_errors.append(rollback_error)
+                logging.exception("Failed to restore managed file %s", destination)
+        if rollback_errors:
+            raise error.CinderError(
+                "Failed to roll back configuration file transaction"
+            ) from rollback_errors[0]
+
+    def _snapshot_active_file(self, destination: Path) -> OriginalFile:
+        """Capture enough active state to restore a failed transaction."""
+        try:
+            existing_mode = destination.lstat().st_mode
+        except FileNotFoundError:
+            return OriginalFile("absent")
+        if stat.S_ISREG(existing_mode):
+            return OriginalFile(
+                "regular",
+                content=destination.read_bytes(),
+                mode=stat.S_IMODE(existing_mode),
+            )
+        if stat.S_ISLNK(existing_mode):
+            return OriginalFile("symlink", content=os.readlink(destination))
+        raise error.CinderError(f"Unsupported active managed file type: {destination}")
+
+    def _restore_original_file(
+        self,
+        destination: Path,
+        original: OriginalFile,
+        temporary_paths: set[Path],
+    ) -> None:
+        """Atomically restore one captured path after a failed transaction."""
+        if original.kind == "absent":
+            destination.unlink(missing_ok=True)
+            return
+        if original.kind == "regular":
+            content = typing.cast(bytes, original.content)
+            mode = typing.cast(int, original.mode)
+            staged = self._stage_managed_file(destination, content, mode)
+        else:
+            target = typing.cast(str, original.content)
+            staged = self._stage_symlink(destination, target)
+        temporary_paths.add(staged)
+        os.replace(staged, destination)
+        temporary_paths.discard(staged)
+
+    def _managed_file_changed(
+        self,
+        original: OriginalFile,
+        managed_file: ManagedFile,
+        content: bytes | None,
+    ) -> bool:
+        """Return whether a prepared output differs from active state."""
+        if original.kind == "absent":
+            return content is not None
+        if content is None:
+            return True
+        return not (
+            original.kind == "regular"
+            and original.mode == managed_file.mode
+            and original.content == content
+        )
+
+    def _stage_managed_file(self, destination: Path, content: bytes, mode: int) -> Path:
+        """Write a restrictive same-directory file ready for replacement."""
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        temporary_path: Path | None = None
+        try:
+            with tempfile.NamedTemporaryFile(
+                mode="w+b",
+                dir=destination.parent,
+                prefix=f".{destination.name}.",
+                delete=False,
+            ) as temporary:
+                temporary_path = Path(temporary.name)
+                os.fchmod(temporary.fileno(), 0o600)
+                temporary.write(content)
+                temporary.flush()
+                os.fsync(temporary.fileno())
+                os.fchmod(temporary.fileno(), mode)
+            return temporary_path
+        except Exception:
+            if temporary_path is not None:
+                temporary_path.unlink(missing_ok=True)
+            raise
+
+    def _stage_symlink(self, destination: Path, target: str) -> Path:
+        """Create a same-directory symlink ready for atomic restoration."""
+        descriptor, temporary_name = tempfile.mkstemp(
+            dir=destination.parent,
+            prefix=f".{destination.name}.symlink.",
+        )
+        os.close(descriptor)
+        temporary_path = Path(temporary_name)
+        temporary_path.unlink()
+        temporary_path.symlink_to(target)
+        return temporary_path
 
     def _render_specific_backend_configs(
         self,
@@ -267,8 +565,12 @@ class CinderVolume(typing.Generic[CONF], abc.ABC):
             }
         return value
 
-    def template(self, snap: Snap) -> list[template.Template]:
-        """Render templates for the Cinder volume service."""
+    def _prepare_configuration_files(
+        self,
+        snap: Snap,
+        backend_contexts: context.CinderBackendContexts | None = None,
+    ) -> list[PreparedFile]:
+        """Prepare all configuration bytes without changing the filesystem."""
         env = jinja2.Environment(
             loader=jinja2.FileSystemLoader(searchpath=self.templates_search_path(snap)),
             keep_trailing_newline=True,
@@ -281,52 +583,95 @@ class CinderVolume(typing.Generic[CONF], abc.ABC):
                 "cinder_ctx": context.cinder_ctx,
             }
         )
-        modified_templates: list[template.Template] = []
         try:
             ctx = self.render_context(snap)
+            if backend_contexts is None:
+                backend_contexts = self.backend_contexts(snap)
+            ctx[backend_contexts.namespace] = self._render_specific_backend_configs(
+                ctx, backend_contexts.context()
+            )
+            return self._prepare_files(snap, env, ctx, backend_contexts)
         except Exception as e:
-            logging.error("Failed to render context: %s", e)
-            return modified_templates
-        backend_contexts = self.backend_contexts(snap)
-        ctx[backend_contexts.namespace] = self._render_specific_backend_configs(
-            ctx, backend_contexts.context()
-        )
-        # process general templates
-        for tpl in self.template_files():
-            if self._process_template(snap, env, tpl, ctx):
-                modified_templates.append(tpl)
-        # process backend specific templates
+            logging.error("Failed to prepare configuration files", exc_info=True)
+            raise error.CinderError("Failed to prepare configuration files") from e
+
+    def _write_configuration_files(
+        self, snap: Snap, prepared: typing.Sequence[PreparedFile]
+    ) -> list[ManagedFile]:
+        """Write prepared configuration files with a stable public error."""
+        try:
+            return self._write_prepared_files(snap, prepared)
+        except Exception as e:
+            logging.error("Failed to write configuration files", exc_info=True)
+            raise error.CinderError("Failed to write configuration files") from e
+
+    def template(self, snap: Snap) -> list[ManagedFile]:
+        """Render templates for the Cinder volume service."""
+        prepared = self._prepare_configuration_files(snap)
+        return self._write_configuration_files(snap, prepared)
+
+    def _existing_managed_backend_files(self, snap: Snap) -> set[Path]:
+        """Return backend files within the snap's explicit ownership scope."""
+        backend_config_dir = snap.paths.common / context.ETC_CINDER_D_CONF_DIR
+        managed_files = set(backend_config_dir.glob("*.conf"))
+        for cleanup_path in context.backend_tls_material_cleanup_paths():
+            cleanup_dir = snap.paths.common / cleanup_path.parent
+            managed_files.update(cleanup_dir.glob(cleanup_path.name))
+        return managed_files
+
+    def _desired_managed_backend_files(
+        self,
+        snap: Snap,
+        backend_contexts: context.CinderBackendContexts,
+    ) -> set[Path]:
+        """Return managed backend paths desired by validated configuration."""
+        backend_config_dir = snap.paths.common / context.ETC_CINDER_D_CONF_DIR
+        desired_files: set[Path] = set()
         for backend_context in backend_contexts.contexts.values():
-            ctx[context.BACKEND_CTX_KEY] = backend_context.context()
-            ctx[context.CINDER_CTX_KEY] = backend_context.backend_name  # type: ignore
             for tpl in backend_context.template_files():
-                if self._process_template(snap, env, tpl, ctx):
-                    modified_templates.append(tpl)
-            ctx.pop(context.CINDER_CTX_KEY)
-            ctx.pop(context.BACKEND_CTX_KEY)
+                output = self._managed_file_destination(snap, tpl)
+                if output.parent == backend_config_dir and output.suffix == ".conf":
+                    desired_files.add(output)
+            for material in backend_context.tls_materials:
+                if material.cleanup and self._backend_tls_material_content(
+                    backend_context, material
+                ):
+                    desired_files.add(self._managed_file_destination(snap, material))
+        return desired_files
 
-        return modified_templates
-
-    def _clear_backend_configs(self, snap: Snap) -> None:
-        """Clear all existing backend configuration files.
-
-        This ensures that when backends are removed from configuration,
-        their template files are also removed from the filesystem.
-        """
-        backend_config_dir = snap.paths.common / "etc/cinder/cinder.conf.d"
-        if not backend_config_dir.exists():
-            return
-
-        # Remove all .conf files in cinder.conf.d directory
-        # These are backend-specific configuration files
-        for conf_file in backend_config_dir.glob("*.conf"):
+    def _remove_backend_files(self, managed_files: typing.Iterable[Path]) -> list[Path]:
+        """Remove known backend files without expanding their ownership scope."""
+        removed: list[Path] = []
+        failures: list[tuple[Path, OSError]] = []
+        for managed_file in managed_files:
             try:
-                logging.debug("Removing backend config file: %s", conf_file)
-                conf_file.unlink()
+                logging.debug("Removing managed backend file: %s", managed_file)
+                managed_file.unlink()
+                removed.append(managed_file)
+            except FileNotFoundError:
+                continue
             except OSError as e:
-                logging.warning(
-                    "Failed to remove backend config file %s: %s", conf_file, e
+                logging.error(
+                    "Failed to remove managed backend file %s: %s", managed_file, e
                 )
+                failures.append((managed_file, e))
+        if failures:
+            failed_paths = ", ".join(str(path) for path, _ in failures)
+            raise error.CinderError(
+                f"Failed to remove managed backend files: {failed_paths}"
+            ) from failures[0][1]
+        return removed
+
+    def _prune_stale_backend_configs(
+        self,
+        snap: Snap,
+        backend_contexts: context.CinderBackendContexts,
+    ) -> list[Path]:
+        """Remove owned backend files absent from successful configuration."""
+        existing_files = self._existing_managed_backend_files(snap)
+        desired_files = self._desired_managed_backend_files(snap, backend_contexts)
+        removed = self._remove_backend_files(existing_files - desired_files)
+        return [path.relative_to(snap.paths.common) for path in removed]
 
 
 class GenericCinderVolume(CinderVolume[configuration.Configuration]):

--- a/cinder_volume/configuration.py
+++ b/cinder_volume/configuration.py
@@ -25,6 +25,7 @@ class ParentConfig(pydantic.BaseModel):
     """Set common model configuration for all models."""
 
     model_config = pydantic.ConfigDict(
+        hide_input_in_errors=True,
         alias_generator=pydantic.AliasGenerator(
             validation_alias=to_kebab,
             serialization_alias=to_kebab,
@@ -146,7 +147,7 @@ class BaseBackendConfiguration(ParentConfig):
     image_volume_cache_max_count: int | None = None
     volume_dd_blocksize: int = Field(default=4096, ge=512)
     volume_backend_name: str
-    driver_ssl_cert: str | None = None
+    driver_ssl_cert: pydantic.SecretStr | None = None
 
 
 class CephConfiguration(BaseBackendConfiguration):
@@ -186,6 +187,9 @@ class HitachiConfiguration(BaseBackendConfiguration):
 
     # Driver selection
     protocol: str = Field(default="fc", pattern="^(fc|iscsi)$")
+
+    # TLS material received as content and rendered into a snap-owned file.
+    hitachi_mirror_ssl_cert: pydantic.SecretStr | None = None
 
 
 class PureConfiguration(BaseBackendConfiguration):
@@ -685,8 +689,12 @@ class NetappConfiguration(BaseBackendConfiguration):
         ),
     )
 
-    # Core required fields
-    netapp_ca_certificate_file: str  # Absolute path to the trusted CA certificate file.
+    # TLS material received as content and rendered into snap-owned files.
+    netapp_ssl_cert_path: pydantic.SecretStr | None = None
+    netapp_private_key_file: pydantic.SecretStr | None = None
+    netapp_certificate_file: pydantic.SecretStr | None = None
+    netapp_ca_certificate_file: pydantic.SecretStr | None = None
+    netapp_certificate_host_validation: bool = False
     protocol: str = Field(default="iscsi", pattern="^(iscsi|nvme)$")
 
 
@@ -721,6 +729,8 @@ class NimbleConfiguration(BaseBackendConfiguration):
     san_login: str  # Username for SAN controller
     san_password: str  # Password for SAN controller
     protocol: str = Field(default="iscsi", pattern="^(iscsi|fc)$")
+    nimble_verify_certificate: bool | None = None
+    nimble_verify_cert_path: pydantic.SecretStr | None = None
 
 
 class OpeneConfiguration(BaseBackendConfiguration):
@@ -915,10 +925,20 @@ class Configuration(BaseConfiguration):
     dellsc: dict[str, DellSCConfiguration] = {}
     dellpowerflex: dict[str, DellpowerflexConfiguration] = {}
     dellpowerstore: dict[str, DellpowerstoreConfiguration] = {}
+    dellpowervault: dict[str, DellpowervaultConfiguration] = {}
     dellunity: dict[str, DellunityConfiguration] = {}
+    fujitsueternusdx: dict[str, FujitsueternusdxConfiguration] = {}
     hpethreepar: dict[str, HpethreeparConfiguration] = {}
     huaweidorado: dict[str, HuaweidoradoConfiguration] = {}
+    ibmgpfs: dict[str, IbmgpfsConfiguration] = {}
     infinidat: dict[str, InfinidatConfiguration] = {}
+    netapp: dict[str, NetappConfiguration] = {}
+    nimble: dict[str, NimbleConfiguration] = {}
+    qnap: dict[str, QnapConfiguration] = {}
+    solidfire: dict[str, SolidfireConfiguration] = {}
+    stx: dict[str, StxConfiguration] = {}
+    synology: dict[str, SynologyConfiguration] = {}
+    zadara: dict[str, ZadaraConfiguration] = {}
 
     @pydantic.model_validator(mode="after")
     def validate_unique_backend_names(self):
@@ -934,10 +954,20 @@ class Configuration(BaseConfiguration):
             ("dellsc", self.dellsc),
             ("dellpowerflex", self.dellpowerflex),
             ("dellpowerstore", self.dellpowerstore),
+            ("dellpowervault", self.dellpowervault),
             ("dellunity", self.dellunity),
+            ("fujitsueternusdx", self.fujitsueternusdx),
             ("hpethreepar", self.hpethreepar),
             ("huaweidorado", self.huaweidorado),
+            ("ibmgpfs", self.ibmgpfs),
             ("infinidat", self.infinidat),
+            ("netapp", self.netapp),
+            ("nimble", self.nimble),
+            ("qnap", self.qnap),
+            ("solidfire", self.solidfire),
+            ("stx", self.stx),
+            ("synology", self.synology),
+            ("zadara", self.zadara),
         ]:
             for backend_key, backend in backends.items():
                 # Check for duplicate backend names across all types

--- a/cinder_volume/context.py
+++ b/cinder_volume/context.py
@@ -9,6 +9,7 @@ import pathlib
 import typing
 
 import jinja2
+import pydantic
 from snaphelpers import Snap
 
 from . import error, template
@@ -55,6 +56,23 @@ class SnapPathContext(Context):
 
 
 ETC_CINDER_D_CONF_DIR = pathlib.Path("etc/cinder/cinder.conf.d")
+
+
+class BackendTLSMaterial(typing.NamedTuple):
+    """Describe one backend TLS material file managed by the snap."""
+
+    content_option: str
+    path_option: str
+    filename: str
+    dest: pathlib.Path
+    mode: int
+    verify_option: str | None = None
+    cleanup: bool = False
+
+    def output_path(self) -> pathlib.Path:
+        """Return the material path relative to its snap location."""
+        return self.dest / self.filename
+
 
 CINDER_CTX_KEY = "ctx_cinder_name"
 BACKEND_CTX_KEY = "ctx_backend"
@@ -104,7 +122,18 @@ def ca_bundle_set(config: template.ContextType) -> bool:
 class BaseBackendContext(Context):
     """Base class for backend context providers."""
 
-    _hidden_keys: typing.Sequence[str] = ("driver_ssl_cert",)
+    _hidden_keys: typing.Sequence[str] = ()
+    supports_driver_ssl_cert = True
+    _tls_materials: typing.Sequence[BackendTLSMaterial] = (
+        BackendTLSMaterial(
+            content_option="driver_ssl_cert",
+            path_option="driver_ssl_cert_path",
+            filename="{backend_name}.pem",
+            dest=ETC_CINDER_D_CONF_DIR,
+            mode=0o640,
+            verify_option="driver_ssl_cert_verify",
+        ),
+    )
 
     def __init__(self, backend_name: str, backend_config: dict[str, typing.Any]):
         """Initialize with backend name and config."""
@@ -120,21 +149,46 @@ class BaseBackendContext(Context):
         necessarily associated with `backend_name`.
         """
         context = dict(self.backend_config)
-        if context.get("driver_ssl_cert"):
-            context["driver_ssl_cert_path"] = str(
-                pathlib.Path(r"{{ snap_paths.common }}")
-                / ETC_CINDER_D_CONF_DIR
-                / f"{self.backend_name}.pem"
+        for material in self.tls_materials:
+            value = context.get(material.content_option)
+            if isinstance(value, pydantic.SecretStr):
+                value = value.get_secret_value()
+            if material.content_option != material.path_option:
+                context.pop(material.content_option, None)
+            if not value:
+                if material.content_option == material.path_option:
+                    context[material.path_option] = None
+                continue
+            context[material.path_option] = str(
+                pathlib.Path(r"{{ snap_paths.common }}") / material.output_path()
             )
-            context["driver_ssl_cert_verify"] = True
+            if material.verify_option:
+                context[material.verify_option] = True
         return context
+
+    @property
+    def tls_materials(self) -> collections.abc.Generator[BackendTLSMaterial]:
+        """TLS material descriptors registered for this backend."""
+        if not self.supports_driver_ssl_cert:
+            return
+        for klass in reversed(self.__class__.mro()):
+            if issubclass(klass, BaseBackendContext):
+                for material in klass.__dict__.get("_tls_materials", ()):
+                    yield material._replace(
+                        filename=material.filename.format(
+                            backend_name=self.backend_name
+                        )
+                    )
 
     @property
     def hidden_keys(self) -> collections.abc.Generator[str]:
         """Keys that should not be exposed in cinder context."""
         for klass in self.__class__.mro():
             if issubclass(klass, BaseBackendContext):
-                yield from klass._hidden_keys
+                yield from klass.__dict__.get("_hidden_keys", ())
+        for material in self.tls_materials:
+            if material.content_option != material.path_option:
+                yield material.content_option
 
     def cinder_context(self) -> typing.Mapping[str, typing.Any]:
         """Context specific for cinder configuration.
@@ -155,17 +209,6 @@ class BaseBackendContext(Context):
                 ETC_CINDER_D_CONF_DIR,
                 template_name="backend.conf.j2",
             ),
-            template.CommonTemplate(
-                f"{self.backend_name}.pem",
-                ETC_CINDER_D_CONF_DIR,
-                template_name="backend.pem.j2",
-                conditionals=[
-                    backend_variable_set(
-                        self.backend_name,
-                        "driver_ssl_cert_path",
-                    )
-                ],
-            ),
         ]
 
     def directories(self) -> list[template.Directory]:
@@ -177,8 +220,22 @@ class BaseBackendContext(Context):
         pass
 
 
+def backend_tls_material_cleanup_paths() -> collections.abc.Generator[pathlib.Path]:
+    """Return relative paths for TLS material owned by backend cleanup."""
+    backend_classes = [BaseBackendContext]
+    while backend_classes:
+        backend_class = backend_classes.pop()
+        backend_classes.extend(backend_class.__subclasses__())
+        for material in backend_class.__dict__.get("_tls_materials", ()):
+            if material.cleanup:
+                yield material.dest / material.filename.format(backend_name="*")
+
+
 class SolidfireBackendContext(BaseBackendContext):
     """Render a NetApp SolidFire backend stanza."""
+
+    _hidden_keys = ("driver_ssl_cert",)
+    supports_driver_ssl_cert = False
 
     def __init__(self, backend_name: str, backend_config: dict):
         """Initialize with backend name and config."""
@@ -642,6 +699,40 @@ class NetappBackendContext(BaseBackendContext):
     """Render a NetApp ONTAP backend stanza."""
 
     _hidden_keys = ("protocol",)
+    _tls_materials = (
+        BackendTLSMaterial(
+            content_option="netapp_ssl_cert_path",
+            path_option="netapp_ssl_cert_path",
+            filename="{backend_name}-netapp-ssl-cert.pem",
+            dest=ETC_CINDER_D_CONF_DIR,
+            mode=0o640,
+            cleanup=True,
+        ),
+        BackendTLSMaterial(
+            content_option="netapp_private_key_file",
+            path_option="netapp_private_key_file",
+            filename="{backend_name}-netapp-private-key.pem",
+            dest=ETC_CINDER_D_CONF_DIR,
+            mode=0o600,
+            cleanup=True,
+        ),
+        BackendTLSMaterial(
+            content_option="netapp_certificate_file",
+            path_option="netapp_certificate_file",
+            filename="{backend_name}-netapp-certificate.pem",
+            dest=ETC_CINDER_D_CONF_DIR,
+            mode=0o640,
+            cleanup=True,
+        ),
+        BackendTLSMaterial(
+            content_option="netapp_ca_certificate_file",
+            path_option="netapp_ca_certificate_file",
+            filename="{backend_name}-netapp-ca-certificate.pem",
+            dest=ETC_CINDER_D_CONF_DIR,
+            mode=0o640,
+            cleanup=True,
+        ),
+    )
 
     def __init__(self, backend_name: str, backend_config: dict):
         """Initialize with backend name and config."""
@@ -690,6 +781,16 @@ class NimbleBackendContext(BaseBackendContext):
     """Render a HPE Nimble Storage backend stanza."""
 
     _hidden_keys = ("protocol",)
+    _tls_materials = (
+        BackendTLSMaterial(
+            content_option="nimble_verify_cert_path",
+            path_option="nimble_verify_cert_path",
+            filename="{backend_name}-nimble-verify-cert.pem",
+            dest=ETC_CINDER_D_CONF_DIR,
+            mode=0o640,
+            cleanup=True,
+        ),
+    )
 
     def __init__(self, backend_name: str, backend_config: dict):
         """Initialize with backend name and config."""
@@ -755,6 +856,9 @@ class ProphetstorBackendContext(BaseBackendContext):
 
 class QnapBackendContext(BaseBackendContext):
     """Render a QNAP Storage backend stanza."""
+
+    _hidden_keys = ("driver_ssl_cert",)
+    supports_driver_ssl_cert = False
 
     def __init__(self, backend_name: str, backend_config: dict):
         """Initialize with backend name and config."""
@@ -992,7 +1096,17 @@ class CephBackendContext(BaseBackendContext):
 class HitachiBackendContext(BaseBackendContext):
     """Render a Hitachi VSP backend stanza."""
 
-    _hidden_keys = ("protocol", "hitachi_mirror_driver_ssl_cert")
+    _hidden_keys = ("protocol",)
+    _tls_materials = (
+        BackendTLSMaterial(
+            content_option="hitachi_mirror_ssl_cert",
+            path_option="hitachi_mirror_ssl_cert_path",
+            filename="{backend_name}_mirror.pem",
+            dest=ETC_CINDER_D_CONF_DIR,
+            mode=0o640,
+            verify_option="hitachi_mirror_ssl_cert_verify",
+        ),
+    )
 
     def __init__(self, backend_name: str, backend_config: dict):
         """Initialize with backend name and config."""
@@ -1017,32 +1131,7 @@ class HitachiBackendContext(BaseBackendContext):
             context["use_chap_auth"] = True
         if "hitachi_mirror_auth_username" in context:
             context["hitachi_mirror_use_chap_auth"] = True
-        if context.get("hitachi_mirror_driver_ssl_cert"):
-            context["hitachi_mirror_ssl_cert_path"] = str(
-                pathlib.Path(r"{{ snap_paths.common }}")
-                / ETC_CINDER_D_CONF_DIR
-                / f"{self.backend_name}_mirror.pem"
-            )
-            context["hitachi_mirror_ssl_cert_verify"] = True
         return context
-
-    def template_files(self) -> list[template.Template]:
-        """Files to be templated."""
-        return super().template_files() + [
-            template.CommonTemplate(
-                f"{self.backend_name}_mirror.pem",
-                ETC_CINDER_D_CONF_DIR,
-                # TODO: find a better pattern when multiple backends
-                # also need a second certificate for the driver
-                template_name="hitachi_backend.pem.j2",
-                conditionals=[
-                    backend_variable_set(
-                        self.backend_name,
-                        "hitachi_mirror_ssl_cert_path",
-                    )
-                ],
-            ),
-        ]
 
 
 class PureBackendContext(BaseBackendContext):
@@ -1142,7 +1231,8 @@ class DellpowerstoreBackendContext(BaseBackendContext):
 class HpethreeparBackendContext(BaseBackendContext):
     """Render a HPE 3Par backend stanza."""
 
-    _hidden_keys = ("protocol",)
+    _hidden_keys = ("protocol", "driver_ssl_cert")
+    supports_driver_ssl_cert = False
 
     def __init__(self, backend_name: str, backend_config: dict):
         """Initialize with backend name and config."""
@@ -1170,7 +1260,8 @@ class HpethreeparBackendContext(BaseBackendContext):
 class InfinidatBackendContext(BaseBackendContext):
     """Render an Infinidat InfiniBox backend stanza."""
 
-    _hidden_keys = ("protocol",)
+    _hidden_keys = ("protocol", "driver_ssl_cert")
+    supports_driver_ssl_cert = False
 
     def __init__(self, backend_name: str, backend_config: dict):
         """Initialize with backend name and config."""

--- a/cinder_volume/templates/backend.pem.j2
+++ b/cinder_volume/templates/backend.pem.j2
@@ -1,1 +1,0 @@
-{{- backend_ctx().driver_ssl_cert }}

--- a/cinder_volume/templates/hitachi_backend.pem.j2
+++ b/cinder_volume/templates/hitachi_backend.pem.j2
@@ -1,1 +1,0 @@
-{{- backend_ctx().hitachi_mirror_driver_ssl_cert }}

--- a/tests/test_backend_templating.py
+++ b/tests/test_backend_templating.py
@@ -10,6 +10,7 @@ and rendered into Cinder configuration files.
 from unittest.mock import Mock, patch
 
 import jinja2
+import pydantic
 import pytest
 
 from cinder_volume import context, error
@@ -30,6 +31,45 @@ class TestBaseBackendContext:
         assert ctx.backend_config == backend_config
         assert ctx.supports_cluster is True
 
+    def test_subclass_tls_material_uses_generic_rendering_path(self):
+        """A subclass descriptor should route content through the base class."""
+
+        class TestBackendContext(context.BaseBackendContext):
+            _tls_materials = (
+                context.BackendTLSMaterial(
+                    content_option="test_tls_content",
+                    path_option="test_tls_path",
+                    filename="{backend_name}-test-tls.pem",
+                    dest=context.ETC_CINDER_D_CONF_DIR,
+                    mode=0o600,
+                    verify_option="test_tls_verify",
+                ),
+            )
+
+        ctx = TestBackendContext(
+            "test-backend",
+            {"test_tls_content": pydantic.SecretStr("PRIVATE_MATERIAL")},
+        )
+
+        cinder_context = ctx.cinder_context()
+        material = next(
+            item
+            for item in ctx.tls_materials
+            if item.content_option == "test_tls_content"
+        )
+
+        assert cinder_context == {
+            "test_tls_path": (
+                "{{ snap_paths.common }}/etc/cinder/cinder.conf.d/"
+                "test-backend-test-tls.pem"
+            ),
+            "test_tls_verify": True,
+        }
+        assert "PRIVATE_MATERIAL" not in str(cinder_context)
+        assert material.filename == "test-backend-test-tls.pem"
+        assert material.dest == context.ETC_CINDER_D_CONF_DIR
+        assert material.mode == 0o600
+
     def test_base_backend_context_context_method(self):
         """Test the context method returns backend config."""
         backend_config = {
@@ -41,18 +81,39 @@ class TestBaseBackendContext:
         result = ctx.context()
         assert result == backend_config
 
-    def test_base_backend_context_with_driver_ssl_cert(self):
-        """Test context method with driver_ssl_cert adds path and verify."""
+    def test_base_backend_context_discards_unsupported_driver_ssl_cert(self):
+        """Unsupported backends never emit a CA path or PEM content."""
         backend_config = {
             "volume_backend_name": "test-backend",
             "driver_ssl_cert": "-----BEGIN CERTIFICATE-----\n...",
         }
-        ctx = context.BaseBackendContext("test-backend", backend_config)
-        result = ctx.context()
+        ctx = context.InfinidatBackendContext("test-backend", backend_config)
+        result = ctx.cinder_context()
 
-        assert "driver_ssl_cert_path" in result
-        assert "test-backend.pem" in result["driver_ssl_cert_path"]
-        assert result["driver_ssl_cert_verify"] is True
+        assert "driver_ssl_cert" not in result
+        assert "driver_ssl_cert_path" not in result
+        assert "driver_ssl_cert_verify" not in result
+
+    def test_driver_ssl_cert_is_registered_only_by_supported_backends(self):
+        """A custom CA is an explicit driver capability."""
+        ctx = context.InfinidatBackendContext("test-backend", {})
+
+        assert list(ctx.tls_materials) == []
+
+        ctx = context.DellpowerstoreBackendContext("test-backend", {})
+
+        materials = {item.content_option: item for item in ctx.tls_materials}
+
+        material = materials["driver_ssl_cert"]
+        assert material.path_option == "driver_ssl_cert_path"
+        assert material.filename == "test-backend.pem"
+        assert material.dest == context.ETC_CINDER_D_CONF_DIR
+        assert material.output_path() == (
+            context.ETC_CINDER_D_CONF_DIR / "test-backend.pem"
+        )
+        assert material.mode == 0o640
+        assert material.verify_option == "driver_ssl_cert_verify"
+        assert material.cleanup is False
 
     def test_base_backend_cinder_context_removes_hidden_keys(self):
         """Test cinder_context removes hidden keys like driver_ssl_cert."""
@@ -86,31 +147,16 @@ class TestBaseBackendContext:
         ctx = context.BaseBackendContext("test-backend", {})
         templates = ctx.template_files()
 
-        assert len(templates) == 2
+        assert len(templates) == 1
         assert templates[0].filename == "test-backend.conf"
         assert templates[0].template_name == "backend.conf.j2"
-        assert templates[1].filename == "test-backend.pem"
-        assert templates[1].template_name == "backend.pem.j2"
 
-    def test_base_backend_pem_template_conditional(self):
-        """Test that .pem template has conditional for driver_ssl_cert_path."""
-        ctx = context.BaseBackendContext("test-backend", {})
-        templates = ctx.template_files()
-        pem_template = templates[1]
+    def test_supported_backend_tls_material_is_not_a_jinja_template(self):
+        """A supported driver's TLS material bypasses Jinja templates."""
+        ctx = context.DellpowerstoreBackendContext("test-backend", {})
 
-        assert len(pem_template.conditionals) > 0
-
-        # Test conditional returns False when cert not present
-        test_context = {"cinder_backends": {"contexts": {"test-backend": {}}}}
-        assert not all(cond(test_context) for cond in pem_template.conditionals)
-
-        # Test conditional returns True when cert is present
-        test_context_with_cert = {
-            "cinder_backends": {
-                "contexts": {"test-backend": {"driver_ssl_cert_path": "/path/to/cert"}}
-            }
-        }
-        assert all(cond(test_context_with_cert) for cond in pem_template.conditionals)
+        assert [item.filename for item in ctx.template_files()] == ["test-backend.conf"]
+        assert [item.filename for item in ctx.tls_materials] == ["test-backend.pem"]
 
     def test_base_backend_directories(self):
         """Test directories returns empty list for base backend."""
@@ -192,6 +238,213 @@ class TestCinderBackendContexts:
         result = cbc.context()
 
         assert result["cluster_ok"] is True
+
+
+class TestHitachiBackendTLSMaterial:
+    """Retain the existing Hitachi mirror TLS material behavior."""
+
+    def test_hitachi_mirror_public_input_routes_to_cinder_path(self):
+        """The charm's mirror certificate input should become a Cinder path."""
+        ctx = context.HitachiBackendContext(
+            "hitachi01",
+            {"hitachi_mirror_ssl_cert": pydantic.SecretStr("MIRROR_CA_CONTENT")},
+        )
+
+        result = ctx.cinder_context()
+        materials = {item.filename: item for item in ctx.tls_materials}
+        material = materials["hitachi01_mirror.pem"]
+
+        assert result["hitachi_mirror_ssl_cert_path"] == (
+            "{{ snap_paths.common }}/etc/cinder/cinder.conf.d/hitachi01_mirror.pem"
+        )
+        assert result["hitachi_mirror_ssl_cert_verify"] is True
+        assert "hitachi_mirror_ssl_cert" not in result
+        assert "MIRROR_CA_CONTENT" not in str(result)
+        assert material.content_option == "hitachi_mirror_ssl_cert"
+
+    def test_hitachi_mirror_tls_material_is_rendered_as_a_path(self):
+        """Test mirror CA content remains hidden behind its rendered path."""
+        ctx = context.HitachiBackendContext(
+            "hitachi01",
+            {
+                "volume_backend_name": "hitachi01",
+                "hitachi_mirror_ssl_cert": pydantic.SecretStr("MIRROR_CA_CONTENT"),
+            },
+        )
+
+        result = ctx.cinder_context()
+        full_context = ctx.context()
+        materials = {item.filename: item for item in ctx.tls_materials}
+
+        assert "MIRROR_CA_CONTENT" not in str(result)
+        assert "hitachi_mirror_ssl_cert" not in full_context
+        assert result["hitachi_mirror_ssl_cert_path"] == (
+            "{{ snap_paths.common }}/etc/cinder/cinder.conf.d/hitachi01_mirror.pem"
+        )
+        assert result["hitachi_mirror_ssl_cert_verify"] is True
+        assert materials["hitachi01_mirror.pem"].mode == 0o640
+
+    def test_hitachi_mirror_tls_material_uses_generic_registry(self):
+        """The Hitachi mirror certificate should be declared generically."""
+        ctx = context.HitachiBackendContext("hitachi01", {})
+
+        materials = {item.content_option: item for item in ctx.tls_materials}
+
+        material = materials["hitachi_mirror_ssl_cert"]
+        assert material.path_option == "hitachi_mirror_ssl_cert_path"
+        assert material.filename == "hitachi01_mirror.pem"
+        assert material.dest == context.ETC_CINDER_D_CONF_DIR
+        assert material.mode == 0o640
+        assert material.verify_option == "hitachi_mirror_ssl_cert_verify"
+        assert material.cleanup is False
+
+
+class TestNetappBackendTLSMaterials:
+    """Characterize NetApp declarations in the generic TLS registry."""
+
+    def test_netapp_tls_materials_use_generic_registry(self):
+        """NetApp should declare all four materials without changing metadata."""
+        ctx = context.NetappBackendContext("ontap01", {})
+
+        materials = {item.content_option: item for item in ctx.tls_materials}
+
+        expected = {
+            "netapp_ssl_cert_path": (
+                "ontap01-netapp-ssl-cert.pem",
+                0o640,
+            ),
+            "netapp_private_key_file": (
+                "ontap01-netapp-private-key.pem",
+                0o600,
+            ),
+            "netapp_certificate_file": (
+                "ontap01-netapp-certificate.pem",
+                0o640,
+            ),
+            "netapp_ca_certificate_file": (
+                "ontap01-netapp-ca-certificate.pem",
+                0o640,
+            ),
+        }
+        for option, (filename, mode) in expected.items():
+            material = materials[option]
+            assert material.path_option == option
+            assert material.filename == filename
+            assert material.dest == context.ETC_CINDER_D_CONF_DIR
+            assert material.mode == mode
+            assert material.verify_option is None
+            assert material.cleanup is True
+
+    def test_cleanup_paths_cover_owned_backend_tls_material_only(self):
+        """Cleanup discovery should include only explicitly owned TLS files."""
+        assert set(context.backend_tls_material_cleanup_paths()) == {
+            context.ETC_CINDER_D_CONF_DIR / "*-netapp-ssl-cert.pem",
+            context.ETC_CINDER_D_CONF_DIR / "*-netapp-private-key.pem",
+            context.ETC_CINDER_D_CONF_DIR / "*-netapp-certificate.pem",
+            context.ETC_CINDER_D_CONF_DIR / "*-netapp-ca-certificate.pem",
+            context.ETC_CINDER_D_CONF_DIR / "*-nimble-verify-cert.pem",
+        }
+
+
+class TestNimbleBackendTLSMaterial:
+    """Characterize Nimble verification certificate material."""
+
+    @pytest.mark.parametrize("verify", [False, True])
+    def test_nimble_tls_material_routes_to_path_without_changing_verify(self, verify):
+        """Nimble certificate content should become a path only."""
+        ctx = context.NimbleBackendContext(
+            "nimble01",
+            {
+                "nimble_verify_cert_path": pydantic.SecretStr("NIMBLE_CA"),
+                "nimble_verify_certificate": verify,
+            },
+        )
+
+        result = ctx.cinder_context()
+        materials = {item.content_option: item for item in ctx.tls_materials}
+        material = materials["nimble_verify_cert_path"]
+
+        assert result["nimble_verify_cert_path"] == (
+            "{{ snap_paths.common }}/etc/cinder/cinder.conf.d/"
+            "nimble01-nimble-verify-cert.pem"
+        )
+        assert result["nimble_verify_certificate"] is verify
+        assert "NIMBLE_CA" not in str(result)
+        assert material.path_option == "nimble_verify_cert_path"
+        assert material.filename == "nimble01-nimble-verify-cert.pem"
+        assert material.dest == context.ETC_CINDER_D_CONF_DIR
+        assert material.mode == 0o640
+        assert material.verify_option is None
+        assert material.cleanup is True
+
+
+@pytest.mark.parametrize(
+    ("backend", "expected"),
+    [
+        (
+            context.DellscBackendContext(
+                "dellsc01",
+                {
+                    "dell_sc_verify_cert": False,
+                    "san_private_key": "/etc/cinder/dellsc.key",
+                },
+            ),
+            {
+                "dell_sc_verify_cert": False,
+                "san_private_key": "/etc/cinder/dellsc.key",
+            },
+        ),
+        (
+            context.FujitsueternusdxBackendContext(
+                "fujitsu01",
+                {
+                    "cinder_eternus_config_file": "/etc/cinder/eternus.xml",
+                    "fujitsu_private_key_path": "$state_path/eternus",
+                },
+            ),
+            {
+                "cinder_eternus_config_file": "/etc/cinder/eternus.xml",
+                "fujitsu_private_key_path": "$state_path/eternus",
+            },
+        ),
+        (
+            context.HuaweidoradoBackendContext(
+                "huawei01",
+                {"cinder_huawei_conf_file": "/etc/cinder/huawei.xml"},
+            ),
+            {"cinder_huawei_conf_file": "/etc/cinder/huawei.xml"},
+        ),
+        (
+            context.IbmgpfsBackendContext(
+                "gpfs01",
+                {
+                    "gpfs_private_key": "/etc/cinder/gpfs.key",
+                    "gpfs_hosts_key_file": "$state_path/ssh_known_hosts",
+                },
+            ),
+            {
+                "gpfs_private_key": "/etc/cinder/gpfs.key",
+                "gpfs_hosts_key_file": "$state_path/ssh_known_hosts",
+            },
+        ),
+        (
+            context.SynologyBackendContext("synology01", {"synology_ssl_verify": True}),
+            {"synology_ssl_verify": True},
+        ),
+        (
+            context.ZadaraBackendContext(
+                "zadara01",
+                {"zadara_vpsa_use_ssl": False, "zadara_ssl_cert_verify": True},
+            ),
+            {"zadara_vpsa_use_ssl": False, "zadara_ssl_cert_verify": True},
+        ),
+    ],
+)
+def test_non_material_paths_and_verification_booleans_pass_through(backend, expected):
+    """Existing Cinder paths and booleans should remain unchanged."""
+    result = backend.cinder_context()
+
+    assert {key: result[key] for key in expected} == expected
 
 
 class TestBackendTemplateRendering:

--- a/tests/test_cinder_volume_runtime.py
+++ b/tests/test_cinder_volume_runtime.py
@@ -1,12 +1,15 @@
 # SPDX-FileCopyrightText: 2025 - Canonical Ltd
 # SPDX-License-Identifier: Apache-2.0
 
+import os
 from pathlib import Path
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 import jinja2
+import pydantic
+import pytest
 
-from cinder_volume import cinder_volume, context, template
+from cinder_volume import cinder_volume, context, error, template
 
 
 def _get_section(rendered: str, section: str) -> str:
@@ -78,6 +81,952 @@ class TestGenericCinderVolume:
             backend_contexts.contexts["infinibox01"], context.InfinidatBackendContext
         )
         assert backend_contexts.context()["cluster_ok"] is False
+
+    def test_backend_contexts_discovers_netapp_backend(self):
+        """Configured NetApp backends should be loaded at runtime."""
+        service = cinder_volume.GenericCinderVolume()
+        snap = Mock()
+        snap.config.get_options.return_value.as_dict.return_value = {
+            "database": {"url": "sqlite:///test.db"},
+            "rabbitmq": {"url": "amqp://localhost"},
+            "cinder": {"project-id": "project-id", "user-id": "user-id"},
+            "netapp": {
+                "ontap01": {
+                    "volume-backend-name": "ontap01",
+                    "netapp-ca-certificate-file": "CA_CONTENT",
+                    "protocol": "iscsi",
+                }
+            },
+        }
+
+        backend_contexts = service.backend_contexts(snap)
+
+        assert list(backend_contexts.contexts) == ["ontap01"]
+        assert isinstance(
+            backend_contexts.contexts["ontap01"], context.NetappBackendContext
+        )
+
+    def test_backend_contexts_discovers_nimble_backend(self):
+        """Configured Nimble backends should reach the runtime context."""
+        service = cinder_volume.GenericCinderVolume()
+        snap = Mock()
+        snap.config.get_options.return_value.as_dict.return_value = {
+            "database": {"url": "sqlite:///test.db"},
+            "rabbitmq": {"url": "amqp://localhost"},
+            "cinder": {"project-id": "project-id", "user-id": "user-id"},
+            "nimble": {
+                "nimble01": {
+                    "volume-backend-name": "nimble01",
+                    "san-ip": "10.0.0.1",
+                    "san-login": "user",
+                    "san-password": "password",
+                    "protocol": "iscsi",
+                    "nimble-verify-cert-path": "NIMBLE_CA",
+                    "nimble-verify-certificate": False,
+                }
+            },
+        }
+
+        backend_contexts = service.backend_contexts(snap)
+
+        assert list(backend_contexts.contexts) == ["nimble01"]
+        backend = backend_contexts.contexts["nimble01"]
+        assert isinstance(backend, context.NimbleBackendContext)
+        assert isinstance(
+            backend.backend_config["nimble_verify_cert_path"],
+            pydantic.SecretStr,
+        )
+
+    def test_backend_contexts_discovers_dellpowervault_backend(self):
+        """Configured Dell PowerVault backends should reach the runtime context."""
+        service = cinder_volume.GenericCinderVolume()
+        snap = Mock()
+        snap.config.get_options.return_value.as_dict.return_value = {
+            "database": {"url": "sqlite:///test.db"},
+            "rabbitmq": {"url": "amqp://localhost"},
+            "cinder": {"project-id": "project-id", "user-id": "user-id"},
+            "dellpowervault": {
+                "vault01": {
+                    "volume-backend-name": "vault01",
+                    "protocol": "iscsi",
+                    "driver-ssl-cert": "POWERVAULT_CA",
+                }
+            },
+        }
+
+        backend_contexts = service.backend_contexts(snap)
+
+        assert list(backend_contexts.contexts) == ["vault01"]
+        backend = backend_contexts.contexts["vault01"]
+        assert isinstance(backend, context.DellpowervaultBackendContext)
+        assert isinstance(backend.backend_config["driver_ssl_cert"], pydantic.SecretStr)
+
+    def test_netapp_tls_material_renders_secure_files_and_paths(self, tmp_path):
+        """NetApp TLS content should be written exactly outside Jinja."""
+        service = cinder_volume.GenericCinderVolume()
+        snap = Mock()
+        snap.paths.common = tmp_path
+        values = {
+            "netapp_ssl_cert_path": "TRANSPORT{{ snap_paths.common }}",
+            "netapp_private_key_file": "PRIVATE{% if unsafe %}KEY{% endif %}",
+            "netapp_certificate_file": "CLIENT_CERT_CONTENT\n",
+            "netapp_ca_certificate_file": "CLIENT_CA_CONTENT",
+        }
+        backend = context.NetappBackendContext(
+            "ontap01",
+            {
+                "volume_backend_name": "ontap01",
+                **values,
+                "netapp_private_key_file": pydantic.SecretStr(
+                    values["netapp_private_key_file"]
+                ),
+                "netapp_certificate_host_validation": False,
+            },
+        )
+        env = jinja2.Environment(
+            loader=jinja2.FileSystemLoader(
+                Path(cinder_volume.__file__).parent / "templates"
+            )
+        )
+        env.globals.update(
+            {
+                "backend_ctx": context.backend_ctx,
+                "cinder_name": context.cinder_name,
+                "cinder_ctx": context.cinder_ctx,
+            }
+        )
+        render_context = {
+            "snap_paths": {"common": tmp_path},
+            "cinder_backends": {"contexts": {"ontap01": backend.cinder_context()}},
+            context.BACKEND_CTX_KEY: backend.context(),
+            context.CINDER_CTX_KEY: "ontap01",
+        }
+        render_context["cinder_backends"]["contexts"]["ontap01"] = (
+            service._render_specific_backend_configs(
+                render_context, backend.cinder_context()
+            )
+        )
+
+        for tpl in backend.template_files():
+            service._process_template(snap, env, tpl, render_context)
+        for material in backend.tls_materials:
+            service._process_backend_tls_material(snap, backend, material)
+
+        backend_dir = tmp_path / "etc/cinder/cinder.conf.d"
+        rendered_config = (backend_dir / "ontap01.conf").read_text()
+        expected = {
+            "ontap01-netapp-ssl-cert.pem": (
+                values["netapp_ssl_cert_path"].encode(),
+                0o640,
+            ),
+            "ontap01-netapp-private-key.pem": (
+                values["netapp_private_key_file"].encode(),
+                0o600,
+            ),
+            "ontap01-netapp-certificate.pem": (
+                values["netapp_certificate_file"].encode(),
+                0o640,
+            ),
+            "ontap01-netapp-ca-certificate.pem": (
+                values["netapp_ca_certificate_file"].encode(),
+                0o640,
+            ),
+        }
+        for filename, (content, mode) in expected.items():
+            material_file = backend_dir / filename
+            assert material_file.read_bytes() == content
+            assert material_file.stat().st_mode & 0o777 == mode
+            assert str(material_file) in rendered_config
+            assert content.decode().strip() not in rendered_config
+        assert "netapp_certificate_host_validation = False" in rendered_config
+
+    def test_nimble_tls_material_renders_secure_file_and_path(self, tmp_path, caplog):
+        """Nimble CA content should stay opaque and out of config and logs."""
+        service = cinder_volume.GenericCinderVolume()
+        snap = Mock()
+        snap.paths.common = tmp_path
+        material_value = "NIMBLE{{ unsafe }}"
+        backend = context.NimbleBackendContext(
+            "nimble01",
+            {
+                "volume_backend_name": "nimble01",
+                "nimble_verify_cert_path": pydantic.SecretStr(material_value),
+                "nimble_verify_certificate": False,
+            },
+        )
+        backends = context.CinderBackendContexts(["nimble01"], {"nimble01": backend})
+        service.render_context = Mock(return_value={"snap_paths": {"common": tmp_path}})
+        service.backend_contexts = Mock(return_value=backends)
+        service.template_files = Mock(return_value=[])
+
+        service.template(snap)
+
+        backend_dir = tmp_path / context.ETC_CINDER_D_CONF_DIR
+        material_file = backend_dir / "nimble01-nimble-verify-cert.pem"
+        rendered_config = (backend_dir / "nimble01.conf").read_text()
+        assert material_file.read_text() == material_value
+        assert material_file.stat().st_mode & 0o777 == 0o640
+        assert f"nimble_verify_cert_path = {material_file}" in rendered_config
+        assert "nimble_verify_certificate = False" in rendered_config
+        assert material_value not in rendered_config
+        assert material_value not in caplog.text
+
+    def test_removing_nimble_tls_option_removes_material_file(self, tmp_path):
+        """Removing Nimble CA content should remove its managed file."""
+        service = cinder_volume.GenericCinderVolume()
+        snap = Mock()
+        snap.paths.common = tmp_path
+        backend = context.NimbleBackendContext("nimble01", {})
+        material = next(
+            item
+            for item in backend.tls_materials
+            if item.content_option == "nimble_verify_cert_path"
+        )
+        material_file = tmp_path / material.output_path()
+        material_file.parent.mkdir(parents=True)
+        material_file.write_text("OLD_NIMBLE_CA")
+
+        changed = service._process_backend_tls_material(snap, backend, material)
+
+        assert changed is True
+        assert not material_file.exists()
+
+    def test_removing_netapp_tls_option_removes_material_file(self, tmp_path):
+        """Removing one NetApp TLS value should unlink its managed file."""
+        service = cinder_volume.GenericCinderVolume()
+        snap = Mock()
+        snap.paths.common = tmp_path
+        material_file = (
+            tmp_path / "etc/cinder/cinder.conf.d/ontap01-netapp-private-key.pem"
+        )
+        material_file.parent.mkdir(parents=True)
+        material_file.write_text("OLD_PRIVATE_KEY\n")
+        backend = context.NetappBackendContext(
+            "ontap01", {"volume_backend_name": "ontap01"}
+        )
+        material = next(
+            item
+            for item in backend.tls_materials
+            if item.filename == "ontap01-netapp-private-key.pem"
+        )
+
+        changed = service._process_backend_tls_material(snap, backend, material)
+
+        assert changed is True
+        assert not material_file.exists()
+
+    @pytest.mark.parametrize(
+        ("backend", "option", "filename", "verify_option"),
+        [
+            (
+                context.BaseBackendContext(
+                    "generic01", {"driver_ssl_cert": "GENERIC{{ value }}"}
+                ),
+                "driver_ssl_cert",
+                "generic01.pem",
+                "driver_ssl_cert_verify",
+            ),
+            (
+                context.HitachiBackendContext(
+                    "hitachi01",
+                    {
+                        "hitachi_mirror_ssl_cert": pydantic.SecretStr(
+                            "MIRROR{% value %}"
+                        )
+                    },
+                ),
+                "hitachi_mirror_ssl_cert",
+                "hitachi01_mirror.pem",
+                "hitachi_mirror_ssl_cert_verify",
+            ),
+        ],
+    )
+    def test_generic_tls_materials_use_direct_writer(
+        self, tmp_path, backend, option, filename, verify_option
+    ):
+        """Generic and Hitachi TLS values should use the shared raw writer."""
+        service = cinder_volume.GenericCinderVolume()
+        snap = Mock()
+        snap.paths.common = tmp_path
+        material = next(
+            item for item in backend.tls_materials if item.content_option == option
+        )
+
+        changed = service._process_backend_tls_material(snap, backend, material)
+
+        output = tmp_path / context.ETC_CINDER_D_CONF_DIR / filename
+        assert changed is True
+        value = backend.backend_config[option]
+        if isinstance(value, pydantic.SecretStr):
+            value = value.get_secret_value()
+        assert output.read_text() == value
+        assert output.stat().st_mode & 0o777 == 0o640
+        assert backend.cinder_context()[verify_option] is True
+
+    def test_hitachi_mirror_material_is_opaque_and_path_only(self, tmp_path, caplog):
+        """Hitachi mirror PEM should stay opaque and out of config and logs."""
+        service = cinder_volume.GenericCinderVolume()
+        snap = Mock()
+        snap.paths.common = tmp_path
+        material_value = "MIRROR{% unsafe %}"
+        backend = context.HitachiBackendContext(
+            "hitachi01",
+            {
+                "volume_backend_name": "hitachi01",
+                "hitachi_mirror_ssl_cert": pydantic.SecretStr(material_value),
+            },
+        )
+        backends = context.CinderBackendContexts(["hitachi01"], {"hitachi01": backend})
+        service.render_context = Mock(return_value={"snap_paths": {"common": tmp_path}})
+        service.backend_contexts = Mock(return_value=backends)
+        service.template_files = Mock(return_value=[])
+
+        service.template(snap)
+
+        backend_dir = tmp_path / context.ETC_CINDER_D_CONF_DIR
+        material_file = backend_dir / "hitachi01_mirror.pem"
+        rendered_config = (backend_dir / "hitachi01.conf").read_text()
+        assert material_file.read_text() == material_value
+        assert material_file.stat().st_mode & 0o777 == 0o640
+        assert f"hitachi_mirror_ssl_cert_path = {material_file}" in rendered_config
+        assert "hitachi_mirror_ssl_cert_verify = True" in rendered_config
+        assert "hitachi_mirror_ssl_cert =" not in rendered_config
+        assert material_value not in rendered_config
+        assert material_value not in caplog.text
+
+    def test_direct_writer_replaces_from_restrictive_same_directory_temp(
+        self, tmp_path
+    ):
+        """A changed material should be replaced from a restrictive peer file."""
+        service = cinder_volume.GenericCinderVolume()
+        snap = Mock()
+        snap.paths.common = tmp_path
+        backend = context.BaseBackendContext(
+            "generic01", {"driver_ssl_cert": "EXACT\n{{ jinja }}"}
+        )
+        material = next(iter(backend.tls_materials))
+
+        with (
+            patch("os.fchmod", wraps=os.fchmod) as fchmod,
+            patch("os.replace", wraps=os.replace) as replace,
+        ):
+            changed = service._process_backend_tls_material(snap, backend, material)
+
+        source, destination = replace.call_args.args
+        assert changed is True
+        assert Path(source).parent == Path(destination).parent
+        assert Path(source) != Path(destination)
+        assert [item.args[1] for item in fchmod.call_args_list] == [0o600, 0o640]
+        assert Path(destination).read_bytes() == b"EXACT\n{{ jinja }}"
+
+    def test_template_writer_replaces_from_same_directory_temp(self, tmp_path):
+        """Rendered configuration should use the shared atomic writer."""
+        service = cinder_volume.GenericCinderVolume()
+        snap = Mock()
+        snap.paths.common = tmp_path
+        env = jinja2.Environment(loader=jinja2.DictLoader({"backend.j2": "NEW"}))
+        tpl = template.CommonTemplate(
+            "backend.conf",
+            context.ETC_CINDER_D_CONF_DIR,
+            template_name="backend.j2",
+        )
+
+        with patch("os.replace", wraps=os.replace) as replace:
+            changed = service._process_template(snap, env, tpl, {})
+
+        source, destination = replace.call_args.args
+        assert changed is True
+        assert Path(source).parent == Path(destination).parent
+        assert Path(destination).read_bytes() == b"NEW\n"
+
+    def test_direct_writer_skips_identical_content_and_mode(self, tmp_path):
+        """An exact existing material should not be replaced."""
+        service = cinder_volume.GenericCinderVolume()
+        snap = Mock()
+        snap.paths.common = tmp_path
+        backend = context.BaseBackendContext(
+            "generic01", {"driver_ssl_cert": "UNCHANGED"}
+        )
+        material = next(iter(backend.tls_materials))
+        output = tmp_path / material.output_path()
+        output.parent.mkdir(parents=True)
+        output.write_bytes(b"UNCHANGED")
+        output.chmod(0o640)
+
+        with patch("os.replace", wraps=os.replace) as replace:
+            changed = service._process_backend_tls_material(snap, backend, material)
+
+        assert changed is False
+        replace.assert_not_called()
+
+    def test_direct_writer_replaces_content_with_wrong_mode(self, tmp_path):
+        """A material with the wrong mode should be atomically replaced."""
+        service = cinder_volume.GenericCinderVolume()
+        snap = Mock()
+        snap.paths.common = tmp_path
+        backend = context.BaseBackendContext(
+            "generic01", {"driver_ssl_cert": "UNCHANGED"}
+        )
+        material = next(iter(backend.tls_materials))
+        output = tmp_path / material.output_path()
+        output.parent.mkdir(parents=True)
+        output.write_bytes(b"UNCHANGED")
+        output.chmod(0o600)
+
+        with patch("os.replace", wraps=os.replace) as replace:
+            changed = service._process_backend_tls_material(snap, backend, material)
+
+        assert changed is True
+        replace.assert_called_once()
+        assert output.stat().st_mode & 0o777 == 0o640
+
+    def test_direct_writer_replaces_symlink_instead_of_following_it(self, tmp_path):
+        """An existing symlink must not satisfy the unchanged-file check."""
+        service = cinder_volume.GenericCinderVolume()
+        snap = Mock()
+        snap.paths.common = tmp_path
+        backend = context.BaseBackendContext("generic01", {"driver_ssl_cert": "SAME"})
+        material = next(iter(backend.tls_materials))
+        target = tmp_path / "operator-owned.pem"
+        target.write_bytes(b"SAME")
+        target.chmod(0o640)
+        output = tmp_path / material.output_path()
+        output.parent.mkdir(parents=True)
+        output.symlink_to(target)
+
+        changed = service._process_backend_tls_material(snap, backend, material)
+
+        assert changed is True
+        assert not output.is_symlink()
+        assert output.read_bytes() == b"SAME"
+        assert target.read_bytes() == b"SAME"
+
+    def test_direct_writer_cleans_temporary_file_after_replace_failure(self, tmp_path):
+        """A failed replacement should not leave raw temporary material behind."""
+        service = cinder_volume.GenericCinderVolume()
+        snap = Mock()
+        snap.paths.common = tmp_path
+        backend = context.BaseBackendContext(
+            "generic01", {"driver_ssl_cert": "SENSITIVE"}
+        )
+        material = next(iter(backend.tls_materials))
+        output_dir = tmp_path / material.dest
+
+        with (
+            patch("os.replace", side_effect=OSError("replace failed")),
+            pytest.raises(OSError, match="replace failed"),
+        ):
+            service._process_backend_tls_material(snap, backend, material)
+
+        assert list(output_dir.iterdir()) == []
+
+    def test_direct_writer_rejects_material_path_outside_destination(self, tmp_path):
+        """A backend name must not redirect TLS material outside its directory."""
+        service = cinder_volume.GenericCinderVolume()
+        snap = Mock()
+        snap.paths.common = tmp_path
+        backend = context.BaseBackendContext(
+            "../escape", {"driver_ssl_cert": "SENSITIVE"}
+        )
+        material = next(iter(backend.tls_materials))
+
+        with pytest.raises(ValueError, match="outside its destination"):
+            service._process_backend_tls_material(snap, backend, material)
+
+        assert not (tmp_path / "etc/cinder/escape.pem").exists()
+
+    def test_template_dispatches_tls_material_to_direct_writer(self, tmp_path):
+        """The rendering lifecycle should process TLS descriptors directly."""
+        service = cinder_volume.GenericCinderVolume()
+        snap = Mock()
+        snap.paths.common = tmp_path
+        backend = context.BaseBackendContext(
+            "generic01", {"driver_ssl_cert": "OPAQUE{{ snap_paths.common }}"}
+        )
+        backends = context.CinderBackendContexts(["generic01"], {"generic01": backend})
+        service.render_context = Mock(return_value={"snap_paths": {"common": tmp_path}})
+        service.backend_contexts = Mock(return_value=backends)
+        service.template_files = Mock(return_value=[])
+        backend.template_files = Mock(return_value=[])
+
+        modified = service.template(snap)
+
+        material = next(iter(backend.tls_materials))
+        assert modified == [material]
+        assert (tmp_path / material.output_path()).read_text() == (
+            "OPAQUE{{ snap_paths.common }}"
+        )
+
+    def test_generic_tls_material_is_opaque_and_path_only(self, tmp_path, caplog):
+        """Generic backend PEM should stay opaque and out of config and logs."""
+        service = cinder_volume.GenericCinderVolume()
+        snap = Mock()
+        snap.paths.common = tmp_path
+        material_value = "GENERIC{{ unsafe }}"
+        backend = context.BaseBackendContext(
+            "generic01",
+            {
+                "volume_backend_name": "generic01",
+                "driver_ssl_cert": pydantic.SecretStr(material_value),
+            },
+        )
+        backends = context.CinderBackendContexts(["generic01"], {"generic01": backend})
+        service.render_context = Mock(return_value={"snap_paths": {"common": tmp_path}})
+        service.backend_contexts = Mock(return_value=backends)
+        service.template_files = Mock(return_value=[])
+
+        service.template(snap)
+
+        backend_dir = tmp_path / context.ETC_CINDER_D_CONF_DIR
+        material_file = backend_dir / "generic01.pem"
+        rendered_config = (backend_dir / "generic01.conf").read_text()
+        assert material_file.read_text() == material_value
+        assert material_file.stat().st_mode & 0o777 == 0o640
+        assert f"driver_ssl_cert_path = {material_file}" in rendered_config
+        assert "driver_ssl_cert_verify = True" in rendered_config
+        assert "driver_ssl_cert =" not in rendered_config
+        assert material_value not in rendered_config
+        assert material_value not in caplog.text
+
+    def test_template_render_failure_preserves_previously_rendered_file(self, tmp_path):
+        """All templates must render successfully before any file is replaced."""
+        service = cinder_volume.GenericCinderVolume()
+        snap = Mock()
+        snap.paths.common = tmp_path
+        templates_dir = tmp_path / "templates"
+        templates_dir.mkdir()
+        (templates_dir / "valid.j2").write_text("NEW_CONTENT")
+        output = tmp_path / context.ETC_CINDER_D_CONF_DIR / "valid.conf"
+        output.parent.mkdir(parents=True)
+        output.write_bytes(b"ACTIVE_CONTENT\n")
+        backend = context.BaseBackendContext("generic01", {})
+        backend.template_files = Mock(return_value=[])
+        backends = context.CinderBackendContexts(["generic01"], {"generic01": backend})
+        service.render_context = Mock(return_value={"snap_paths": {"common": tmp_path}})
+        service.backend_contexts = Mock(return_value=backends)
+        service.template_files = Mock(
+            return_value=[
+                template.CommonTemplate(
+                    "valid.conf",
+                    context.ETC_CINDER_D_CONF_DIR,
+                    template_name="valid.j2",
+                ),
+                template.CommonTemplate(
+                    "missing.conf",
+                    context.ETC_CINDER_D_CONF_DIR,
+                    template_name="missing.j2",
+                ),
+            ]
+        )
+
+        with pytest.raises(error.CinderError, match="prepare configuration files"):
+            service.template(snap)
+
+        assert output.read_bytes() == b"ACTIVE_CONTENT\n"
+
+    def test_prepared_files_reject_duplicate_destinations_before_writing(
+        self, tmp_path
+    ):
+        """Two descriptors must not manage the same resolved destination."""
+        service = cinder_volume.GenericCinderVolume()
+        snap = Mock()
+        snap.paths.common = tmp_path
+        first = template.CommonTemplate("duplicate.conf", context.ETC_CINDER_D_CONF_DIR)
+        second = template.CommonTemplate(
+            "duplicate.conf", context.ETC_CINDER_D_CONF_DIR
+        )
+        output = tmp_path / first.output_path()
+        output.parent.mkdir(parents=True)
+        output.write_bytes(b"ACTIVE\n")
+
+        with pytest.raises(error.CinderError, match="duplicate managed destination"):
+            service._write_prepared_files(
+                snap, [(first, b"FIRST\n"), (second, b"SECOND\n")]
+            )
+
+        assert output.read_bytes() == b"ACTIVE\n"
+
+    def test_configure_rejects_duplicate_destinations_before_setup(self, tmp_path):
+        """Destination ownership must be unique before directory mutation."""
+        service = cinder_volume.GenericCinderVolume()
+        snap = Mock()
+        snap.paths.common = tmp_path
+        templates_dir = tmp_path / "templates"
+        templates_dir.mkdir()
+        (templates_dir / "duplicate.j2").write_text("CONTENT")
+        duplicate = template.CommonTemplate(
+            "duplicate.conf",
+            context.ETC_CINDER_D_CONF_DIR,
+            template_name="duplicate.j2",
+        )
+        service.template_files = Mock(return_value=[duplicate, duplicate])
+        service.render_context = Mock(return_value={"snap_paths": {"common": tmp_path}})
+        backend = context.BaseBackendContext("generic01", {})
+        backend.template_files = Mock(return_value=[])
+        backends = context.CinderBackendContexts(["generic01"], {"generic01": backend})
+        service.backend_contexts = Mock(return_value=backends)
+        service.setup_dirs = Mock()
+
+        with pytest.raises(error.CinderError, match="prepare configuration files"):
+            service.configure(snap)
+
+        service.setup_dirs.assert_not_called()
+        assert not (tmp_path / duplicate.output_path()).exists()
+
+    def test_prepared_files_roll_back_after_later_replace_failure(self, tmp_path):
+        """A failed later replacement must restore earlier active files."""
+        service = cinder_volume.GenericCinderVolume()
+        snap = Mock()
+        snap.paths.common = tmp_path
+        first = template.CommonTemplate("first.conf", context.ETC_CINDER_D_CONF_DIR)
+        second = template.CommonTemplate("second.conf", context.ETC_CINDER_D_CONF_DIR)
+        first_output = tmp_path / first.output_path()
+        second_output = tmp_path / second.output_path()
+        first_output.parent.mkdir(parents=True)
+        first_output.write_bytes(b"ACTIVE_FIRST\n")
+        second_output.write_bytes(b"ACTIVE_SECOND\n")
+        real_replace = os.replace
+        replacements = 0
+
+        def fail_second_replace(source, destination):
+            nonlocal replacements
+            if Path(destination) in {first_output, second_output}:
+                replacements += 1
+            if replacements == 2:
+                raise OSError("replace failed")
+            return real_replace(source, destination)
+
+        with (
+            patch("os.replace", side_effect=fail_second_replace),
+            pytest.raises(OSError, match="replace failed"),
+        ):
+            service._write_prepared_files(
+                snap, [(first, b"NEW_FIRST\n"), (second, b"NEW_SECOND\n")]
+            )
+
+        assert first_output.read_bytes() == b"ACTIVE_FIRST\n"
+        assert second_output.read_bytes() == b"ACTIVE_SECOND\n"
+        assert list(first_output.parent.glob(".*")) == []
+
+    def test_prepared_files_replace_before_deleting(self, tmp_path):
+        """All replacements must finish before requested deletions begin."""
+        service = cinder_volume.GenericCinderVolume()
+        snap = Mock()
+        snap.paths.common = tmp_path
+        removed = template.CommonTemplate("removed.conf", context.ETC_CINDER_D_CONF_DIR)
+        replaced = template.CommonTemplate(
+            "replaced.conf", context.ETC_CINDER_D_CONF_DIR
+        )
+        removed_output = tmp_path / removed.output_path()
+        replaced_output = tmp_path / replaced.output_path()
+        removed_output.parent.mkdir(parents=True)
+        removed_output.write_bytes(b"REMOVE\n")
+        replaced_output.write_bytes(b"ACTIVE\n")
+        real_replace = os.replace
+        real_unlink = Path.unlink
+        operations = []
+
+        def observe_replace(source, destination):
+            if Path(destination) == replaced_output:
+                operations.append("replace")
+            return real_replace(source, destination)
+
+        def observe_unlink(path, *args, **kwargs):
+            if path == removed_output:
+                operations.append("delete")
+            return real_unlink(path, *args, **kwargs)
+
+        with (
+            patch("os.replace", side_effect=observe_replace),
+            patch.object(Path, "unlink", autospec=True, side_effect=observe_unlink),
+        ):
+            service._write_prepared_files(snap, [(removed, None), (replaced, b"NEW\n")])
+
+        assert operations == ["replace", "delete"]
+
+    def test_prepared_files_roll_back_after_later_delete_failure(self, tmp_path):
+        """A failed deletion must restore replacements and earlier deletions."""
+        service = cinder_volume.GenericCinderVolume()
+        snap = Mock()
+        snap.paths.common = tmp_path
+        replaced = template.CommonTemplate(
+            "replaced.conf", context.ETC_CINDER_D_CONF_DIR
+        )
+        first_removed = template.CommonTemplate(
+            "first-removed.conf", context.ETC_CINDER_D_CONF_DIR
+        )
+        second_removed = template.CommonTemplate(
+            "second-removed.conf", context.ETC_CINDER_D_CONF_DIR
+        )
+        outputs = {
+            replaced: tmp_path / replaced.output_path(),
+            first_removed: tmp_path / first_removed.output_path(),
+            second_removed: tmp_path / second_removed.output_path(),
+        }
+        outputs[replaced].parent.mkdir(parents=True)
+        for managed_file, output in outputs.items():
+            output.write_bytes(f"ACTIVE_{managed_file.filename}\n".encode())
+        real_unlink = Path.unlink
+
+        def fail_second_delete(path, *args, **kwargs):
+            if path == outputs[second_removed]:
+                raise PermissionError("delete failed")
+            return real_unlink(path, *args, **kwargs)
+
+        with (
+            patch.object(Path, "unlink", autospec=True, side_effect=fail_second_delete),
+            pytest.raises(PermissionError, match="delete failed"),
+        ):
+            service._write_prepared_files(
+                snap,
+                [(replaced, b"NEW\n"), (first_removed, None), (second_removed, None)],
+            )
+
+        for managed_file, output in outputs.items():
+            assert output.read_bytes() == (f"ACTIVE_{managed_file.filename}\n".encode())
+        assert list(outputs[replaced].parent.glob(".*")) == []
+
+    def test_prepared_files_restore_symlink_after_later_failure(self, tmp_path):
+        """Rollback must restore a symlink without modifying its target."""
+        service = cinder_volume.GenericCinderVolume()
+        snap = Mock()
+        snap.paths.common = tmp_path
+        symlink_file = template.CommonTemplate(
+            "linked.conf", context.ETC_CINDER_D_CONF_DIR
+        )
+        later_file = template.CommonTemplate(
+            "later.conf", context.ETC_CINDER_D_CONF_DIR
+        )
+        symlink_output = tmp_path / symlink_file.output_path()
+        later_output = tmp_path / later_file.output_path()
+        symlink_output.parent.mkdir(parents=True)
+        target = tmp_path / "operator-owned.conf"
+        target.write_bytes(b"OPERATOR\n")
+        symlink_output.symlink_to(target)
+        later_output.write_bytes(b"ACTIVE_LATER\n")
+        real_replace = os.replace
+
+        def fail_later_replace(source, destination):
+            if Path(destination) == later_output:
+                raise OSError("replace failed")
+            return real_replace(source, destination)
+
+        with (
+            patch("os.replace", side_effect=fail_later_replace),
+            pytest.raises(OSError, match="replace failed"),
+        ):
+            service._write_prepared_files(
+                snap, [(symlink_file, b"NEW\n"), (later_file, b"NEW_LATER\n")]
+            )
+
+        assert symlink_output.is_symlink()
+        assert symlink_output.resolve() == target
+        assert target.read_bytes() == b"OPERATOR\n"
+        assert later_output.read_bytes() == b"ACTIVE_LATER\n"
+        assert list(symlink_output.parent.glob(".*")) == []
+
+    def test_prepared_replacements_keep_active_paths_present(self, tmp_path):
+        """Replacing files must never rename active paths out of the way."""
+        service = cinder_volume.GenericCinderVolume()
+        snap = Mock()
+        snap.paths.common = tmp_path
+        managed_file = template.CommonTemplate(
+            "active.conf", context.ETC_CINDER_D_CONF_DIR
+        )
+        output = tmp_path / managed_file.output_path()
+        output.parent.mkdir(parents=True)
+        output.write_bytes(b"ACTIVE\n")
+        real_replace = os.replace
+        active_path_states = []
+
+        def observe_replace(source, destination):
+            if Path(destination) == output:
+                active_path_states.append(output.exists())
+            return real_replace(source, destination)
+
+        with patch("os.replace", side_effect=observe_replace):
+            service._write_prepared_files(snap, [(managed_file, b"NEW\n")])
+
+        assert active_path_states == [True]
+        assert output.read_bytes() == b"NEW\n"
+
+    def test_removing_netapp_backend_removes_owned_material_only(self, tmp_path):
+        """Backend cleanup should remove only owned NetApp TLS files."""
+        service = cinder_volume.GenericCinderVolume()
+        snap = Mock()
+        snap.paths.common = tmp_path
+        backend_dir = tmp_path / "etc/cinder/cinder.conf.d"
+        backend_dir.mkdir(parents=True)
+        owned_files = [
+            backend_dir / "ontap01-netapp-ssl-cert.pem",
+            backend_dir / "ontap01-netapp-private-key.pem",
+            backend_dir / "ontap01-netapp-certificate.pem",
+            backend_dir / "ontap01-netapp-ca-certificate.pem",
+        ]
+        for owned_file in owned_files:
+            owned_file.write_text("STALE_MATERIAL\n")
+        unrelated_file = backend_dir / "operator-managed.pem"
+        unrelated_file.write_text("KEEP\n")
+
+        service._remove_backend_files(service._existing_managed_backend_files(snap))
+
+        assert all(not owned_file.exists() for owned_file in owned_files)
+        assert unrelated_file.read_text() == "KEEP\n"
+
+    def test_removing_nimble_backend_removes_owned_material_only(self, tmp_path):
+        """Backend cleanup should remove owned Nimble CA material only."""
+        service = cinder_volume.GenericCinderVolume()
+        snap = Mock()
+        snap.paths.common = tmp_path
+        backend_dir = tmp_path / context.ETC_CINDER_D_CONF_DIR
+        backend_dir.mkdir(parents=True)
+        owned_file = backend_dir / "nimble01-nimble-verify-cert.pem"
+        owned_file.write_text("STALE_NIMBLE_CA\n")
+        unrelated_file = backend_dir / "operator-managed.pem"
+        unrelated_file.write_text("KEEP\n")
+
+        service._remove_backend_files(service._existing_managed_backend_files(snap))
+
+        assert not owned_file.exists()
+        assert unrelated_file.read_text() == "KEEP\n"
+
+    def test_configure_preserves_active_tls_material_when_validation_fails(
+        self, tmp_path
+    ):
+        """Invalid replacement config must not remove active TLS material."""
+        service = cinder_volume.GenericCinderVolume()
+        service.backend_contexts = Mock(
+            side_effect=error.CinderError("Invalid configuration")
+        )
+        snap = Mock()
+        snap.paths.common = tmp_path
+        material_file = (
+            tmp_path / "etc/cinder/cinder.conf.d/ontap01-netapp-private-key.pem"
+        )
+        material_file.parent.mkdir(parents=True)
+        material_file.write_bytes(b"ACTIVE_PRIVATE_KEY")
+        material_file.chmod(0o600)
+
+        with pytest.raises(error.CinderError, match="Invalid configuration"):
+            service.configure(snap)
+
+        assert material_file.read_bytes() == b"ACTIVE_PRIVATE_KEY"
+        assert material_file.stat().st_mode & 0o777 == 0o600
+
+    def test_configure_preserves_active_files_when_rendering_fails(self, tmp_path):
+        """A rendering failure must not clear active backend files."""
+        service = cinder_volume.GenericCinderVolume()
+        backend = context.BaseBackendContext("generic01", {})
+        backends = context.CinderBackendContexts(["generic01"], {"generic01": backend})
+        service.backend_contexts = Mock(return_value=backends)
+        service._prepare_configuration_files = Mock(
+            side_effect=error.CinderError("Failed to prepare configuration files")
+        )
+        service.setup_dirs = Mock()
+        snap = Mock()
+        snap.paths.common = tmp_path
+        active_file = (
+            tmp_path / "etc/cinder/cinder.conf.d/ontap01-netapp-private-key.pem"
+        )
+        active_file.parent.mkdir(parents=True)
+        active_file.write_bytes(b"ACTIVE_PRIVATE_KEY")
+
+        with pytest.raises(error.CinderError, match="prepare configuration files"):
+            service.configure(snap)
+
+        assert active_file.read_bytes() == b"ACTIVE_PRIVATE_KEY"
+        service.setup_dirs.assert_not_called()
+
+    def test_configure_prunes_only_stale_files_after_success(self, tmp_path):
+        """Successful configure should preserve desired files and remove stale ones."""
+        service = cinder_volume.GenericCinderVolume()
+        backend = context.BaseBackendContext("generic01", {})
+        backends = context.CinderBackendContexts(["generic01"], {"generic01": backend})
+        service.backend_contexts = Mock(return_value=backends)
+        service._prepare_configuration_files = Mock(return_value=[])
+        service._write_configuration_files = Mock(return_value=[])
+        service.start_services = Mock()
+        snap = Mock()
+        snap.paths.common = tmp_path
+        backend_dir = tmp_path / context.ETC_CINDER_D_CONF_DIR
+        backend_dir.mkdir(parents=True)
+        desired_file = backend_dir / "generic01.conf"
+        desired_file.write_bytes(b"ACTIVE_CONFIG\n")
+        stale_file = backend_dir / "removed.conf"
+        stale_file.write_bytes(b"STALE_CONFIG\n")
+
+        service.configure(snap)
+
+        assert desired_file.read_bytes() == b"ACTIVE_CONFIG\n"
+        assert not stale_file.exists()
+
+    def test_prune_failure_aborts_configuration(self, tmp_path):
+        """Incomplete stale-file cleanup must fail configuration."""
+        service = cinder_volume.GenericCinderVolume()
+        backend = context.BaseBackendContext("generic01", {})
+        backends = context.CinderBackendContexts(["generic01"], {"generic01": backend})
+        service.backend_contexts = Mock(return_value=backends)
+        service._prepare_configuration_files = Mock(return_value=[])
+        service._write_configuration_files = Mock(return_value=[])
+        service.start_services = Mock()
+        snap = Mock()
+        snap.paths.common = tmp_path
+        stale_file = tmp_path / context.ETC_CINDER_D_CONF_DIR / "removed.conf"
+        stale_file.parent.mkdir(parents=True)
+        stale_file.write_bytes(b"STALE_CONFIG\n")
+
+        with (
+            patch.object(Path, "unlink", side_effect=PermissionError("denied")),
+            pytest.raises(error.CinderError, match="remove managed backend files"),
+        ):
+            service.configure(snap)
+
+        service.start_services.assert_not_called()
+
+    def test_prune_only_change_is_reported_for_service_restart(self, tmp_path):
+        """Removing a stale backend file must be a restart-triggering change."""
+        service = cinder_volume.GenericCinderVolume()
+        backend = context.BaseBackendContext("generic01", {})
+        backends = context.CinderBackendContexts(["generic01"], {"generic01": backend})
+        service.backend_contexts = Mock(return_value=backends)
+        service._prepare_configuration_files = Mock(return_value=[])
+        service._write_configuration_files = Mock(return_value=[])
+        service.start_services = Mock()
+        snap = Mock()
+        snap.paths.common = tmp_path
+        stale_file = tmp_path / context.ETC_CINDER_D_CONF_DIR / "removed.conf"
+        stale_file.parent.mkdir(parents=True)
+        stale_file.write_bytes(b"STALE_CONFIG\n")
+
+        service.configure(snap)
+
+        modified, backend_files = service.start_services.call_args.args[1:]
+        relative_stale = stale_file.relative_to(tmp_path)
+        assert relative_stale in modified
+        assert relative_stale in backend_files
+
+    def test_configure_preserves_owned_material_when_no_backends_validate(
+        self, tmp_path
+    ):
+        """An invalid empty backend set must preserve active material."""
+        service = cinder_volume.GenericCinderVolume()
+        service.backend_contexts = Mock(
+            side_effect=error.CinderError("At least one backend must be enabled")
+        )
+        snap = Mock()
+        snap.paths.common = tmp_path
+        material_file = (
+            tmp_path / "etc/cinder/cinder.conf.d/ontap01-netapp-private-key.pem"
+        )
+        material_file.parent.mkdir(parents=True)
+        material_file.write_bytes(b"STALE_PRIVATE_KEY")
+
+        with pytest.raises(
+            error.CinderError, match="At least one backend must be enabled"
+        ):
+            service.configure(snap)
+
+        assert material_file.read_bytes() == b"STALE_PRIVATE_KEY"
 
     def test_cinder_conf_renders_cafile_when_ca_bundle_exists(self):
         """The template should render CA settings in the service-specific sections."""

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -35,6 +35,85 @@ class TestParentConfig:
         assert hasattr(config, "model_config")
 
 
+@pytest.mark.parametrize(
+    ("config_type", "backend_config", "field", "material"),
+    [
+        (
+            configuration.BaseBackendConfiguration,
+            {
+                "volume-backend-name": "generic01",
+                "driver-ssl-cert": "GENERIC_PEM",
+            },
+            "driver_ssl_cert",
+            "GENERIC_PEM",
+        ),
+        (
+            configuration.HitachiConfiguration,
+            {
+                "volume-backend-name": "hitachi01",
+                "san-ip": "10.0.0.1",
+                "san-login": "user",
+                "san-password": "password",
+                "hitachi-storage-id": "storage",
+                "hitachi-pools": "pool",
+                "hitachi-mirror-ssl-cert": "MIRROR_PEM",
+            },
+            "hitachi_mirror_ssl_cert",
+            "MIRROR_PEM",
+        ),
+        (
+            configuration.NimbleConfiguration,
+            {
+                "volume-backend-name": "nimble01",
+                "san-ip": "10.0.0.1",
+                "san-login": "user",
+                "san-password": "password",
+                "nimble-verify-cert-path": "NIMBLE_CA",
+            },
+            "nimble_verify_cert_path",
+            "NIMBLE_CA",
+        ),
+    ],
+)
+def test_backend_tls_material_is_masked(config_type, backend_config, field, material):
+    """Raw backend TLS values should be secret-aware model fields."""
+    config = config_type(**backend_config)
+
+    value = config.model_dump()[field]
+    assert isinstance(value, pydantic.SecretStr)
+    assert material not in repr(config)
+
+
+def test_validation_error_hides_tls_material_input():
+    """Validation errors should not include rejected TLS material input."""
+    material = "RAW_TLS_MATERIAL_MUST_NOT_APPEAR"
+
+    with pytest.raises(pydantic.ValidationError) as exc_info:
+        configuration.BaseBackendConfiguration(
+            **{
+                "volume-backend-name": "generic01",
+                "driver-ssl-cert": {"content": material},
+            }
+        )
+
+    assert material not in str(exc_info.value)
+
+
+def test_audited_backends_are_registered_at_runtime():
+    """Advertised backends with audited options must be discoverable."""
+    assert {
+        "dellpowervault",
+        "fujitsueternusdx",
+        "ibmgpfs",
+        "nimble",
+        "qnap",
+        "solidfire",
+        "stx",
+        "synology",
+        "zadara",
+    } <= set(configuration.Configuration.model_fields)
+
+
 class TestCAConfiguration:
     """Test the CAConfiguration class."""
 
@@ -1726,16 +1805,56 @@ class TestNetappConfiguration:
         )
         assert config.volume_backend_name == "netapp01"
 
-    def test_netapp_requires_netapp_ca_certificate_file(self):
-        """Test netapp-ca-certificate-file is required."""
-        kwargs = {
-            "volume-backend-name": "netapp01",
-            "netapp-ca-certificate-file": "secret",
-            "protocol": "iscsi",
-        }
-        del kwargs["netapp-ca-certificate-file"]
-        with pytest.raises(pydantic.ValidationError):
-            configuration.NetappConfiguration(**kwargs)
+    def test_netapp_accepts_tls_material_content(self):
+        """Test all NetApp TLS material fields accept content."""
+        assert {
+            "netapp_ssl_cert_path",
+            "netapp_private_key_file",
+            "netapp_certificate_file",
+            "netapp_ca_certificate_file",
+            "netapp_certificate_host_validation",
+        } <= configuration.NetappConfiguration.model_fields.keys()
+        config = configuration.NetappConfiguration(
+            **{
+                "volume-backend-name": "netapp01",
+                "netapp-ssl-cert-path": "TRANSPORT_CA",
+                "netapp-private-key-file": "PRIVATE_KEY",
+                "netapp-certificate-file": "CLIENT_CERT",
+                "netapp-ca-certificate-file": "CLIENT_CA",
+                "netapp-certificate-host-validation": False,
+                "protocol": "iscsi",
+            }
+        )
+
+        data = config.model_dump()
+        assert data["netapp_ssl_cert_path"].get_secret_value() == "TRANSPORT_CA"
+        assert data["netapp_private_key_file"].get_secret_value() == "PRIVATE_KEY"
+        assert data["netapp_certificate_file"].get_secret_value() == "CLIENT_CERT"
+        assert data["netapp_ca_certificate_file"].get_secret_value() == "CLIENT_CA"
+        assert data["netapp_certificate_host_validation"] is False
+
+    def test_netapp_tls_material_is_masked(self):
+        """Test TLS material is not exposed in model representations."""
+        config = configuration.NetappConfiguration(
+            **{
+                "volume-backend-name": "netapp01",
+                "netapp-private-key-file": "PRIVATE_KEY_CONTENT",
+                "protocol": "iscsi",
+            }
+        )
+
+        assert "PRIVATE_KEY_CONTENT" not in repr(config)
+
+    def test_netapp_tls_material_is_optional(self):
+        """Test a NetApp backend can omit all TLS material."""
+        config = configuration.NetappConfiguration(
+            **{"volume-backend-name": "netapp01", "protocol": "iscsi"}
+        )
+
+        assert config.netapp_ssl_cert_path is None
+        assert config.netapp_private_key_file is None
+        assert config.netapp_certificate_file is None
+        assert config.netapp_ca_certificate_file is None
 
     def test_netapp_rejects_invalid_protocol(self):
         """Test that an invalid protocol value is rejected."""

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -3,7 +3,7 @@
 
 from unittest.mock import Mock
 
-from cinder_volume import context
+from cinder_volume import configuration, context
 
 
 class TestConfigContext:
@@ -702,6 +702,75 @@ class TestNetappBackendContext:
         )
         result = ctx.cinder_context()
         assert "protocol" not in result
+
+    def test_netapp_tls_material_is_replaced_with_paths(self):
+        """Test Cinder receives paths without raw NetApp TLS material."""
+        backend_config = configuration.NetappConfiguration(
+            **{
+                "volume-backend-name": "mybackend",
+                "netapp-ssl-cert-path": "TRANSPORT_CA_CONTENT",
+                "netapp-private-key-file": "PRIVATE_KEY_CONTENT",
+                "netapp-certificate-file": "CLIENT_CERT_CONTENT",
+                "netapp-ca-certificate-file": "CLIENT_CA_CONTENT",
+                "netapp-certificate-host-validation": False,
+            }
+        ).model_dump()
+        ctx = context.NetappBackendContext("mybackend", backend_config)
+
+        result = ctx.cinder_context()
+
+        common = "{{ snap_paths.common }}/etc/cinder/cinder.conf.d"
+        assert result["netapp_ssl_cert_path"] == (
+            f"{common}/mybackend-netapp-ssl-cert.pem"
+        )
+        assert result["netapp_private_key_file"] == (
+            f"{common}/mybackend-netapp-private-key.pem"
+        )
+        assert result["netapp_certificate_file"] == (
+            f"{common}/mybackend-netapp-certificate.pem"
+        )
+        assert result["netapp_ca_certificate_file"] == (
+            f"{common}/mybackend-netapp-ca-certificate.pem"
+        )
+        assert result["netapp_certificate_host_validation"] is False
+        for material in (
+            "TRANSPORT_CA_CONTENT",
+            "PRIVATE_KEY_CONTENT",
+            "CLIENT_CERT_CONTENT",
+            "CLIENT_CA_CONTENT",
+        ):
+            assert material not in str(result)
+
+    def test_netapp_tls_material_is_not_added_to_jinja_context(self):
+        """Test raw material is replaced by its path without hidden Jinja keys."""
+        backend_config = configuration.NetappConfiguration(
+            **{
+                "volume-backend-name": "mybackend",
+                "netapp-private-key-file": "PRIVATE_KEY_CONTENT",
+            }
+        ).model_dump()
+        ctx = context.NetappBackendContext("mybackend", backend_config)
+
+        full_context = ctx.context()
+        cinder_context = ctx.cinder_context()
+
+        assert "PRIVATE_KEY_CONTENT" not in str(full_context)
+        assert "_netapp_private_key_file_content" not in full_context
+        assert "_netapp_private_key_file_content" not in cinder_context
+
+    def test_netapp_tls_material_descriptors_have_secure_modes(self):
+        """Test private and public NetApp TLS files use secure modes."""
+        ctx = context.NetappBackendContext("mybackend", {})
+
+        materials = {item.filename: item for item in ctx.tls_materials}
+
+        assert materials["mybackend-netapp-private-key.pem"].mode == 0o600
+        for filename in (
+            "mybackend-netapp-ssl-cert.pem",
+            "mybackend-netapp-certificate.pem",
+            "mybackend-netapp-ca-certificate.pem",
+        ):
+            assert materials[filename].mode == 0o640
 
 
 class TestNexentaBackendContext:


### PR DESCRIPTION
Register NetApp as a runtime backend and render its four TLS material values into snap-owned files. Route generic, NetApp, and Hitachi TLS material through driver-neutral descriptors while preserving their Cinder options, filenames, permissions, verification behavior, and cleanup boundaries.

Write backend certificates and private keys through a shared same-directory atomic writer so their bytes are never evaluated as templates. Keep filename, destination, mode, presence, verification, and cleanup policy in BackendTLSMaterial descriptors.

Prepare and validate every output before changing the filesystem. Stage and atomically install replacements before deletions, restore captured active state when an operation fails, and prune stale owned files only after successful backend setup. Preserve active files when backend validation fails, including an empty backend set.

Partial-Bug: #2161732
Assisted-By: Codex (gpt-5-6-sol)