### PR TITLE
fix: tolerate incomplete config in install hook

### DIFF
--- a/.github/workflows/build-snap.yaml
+++ b/.github/workflows/build-snap.yaml
@@ -10,3 +10,5 @@ jobs:
         uses: actions/checkout@v6
       - name: Build snap locally
         uses: canonical/action-build@v1.3.0
+      - name: Install snap
+        run: sudo snap install --dangerous cinder-volume_*.snap

--- a/cinder_volume/cinder_volume.py
+++ b/cinder_volume/cinder_volume.py
@@ -57,7 +57,10 @@ class CinderVolume(typing.Generic[CONF], abc.ABC):
     def install_hook(cls, snap: Snap) -> None:
         """Install hook for the Cinder volume snap."""
         log.setup_logging(snap.paths.common / "hooks.log")
-        cls().install(snap)
+        try:
+            cls().install(snap)
+        except error.CinderError:
+            logging.warning("Configuration not complete", exc_info=True)
 
     @classmethod
     def configure_hook(cls, snap: Snap) -> None:


### PR DESCRIPTION
Regression from https://github.com/canonical/snap-cinder-volume/commit/fb1ef7f1cb88b71714835ec56ab4e1a9203dcca3 ("fix: ensure backend tls materials correctly
templated"). Previously template() caught context rendering errors and
returned quietly, so installing the snap before setting any
configuration worked. https://github.com/canonical/snap-cinder-volume/commit/fb1ef7f1cb88b71714835ec56ab4e1a9203dcca3 made _prepare_configuration_files()
raise CinderError when required snap configuration (database,
rabbitmq, cinder) is missing, and the install hook does not catch it,
so the snap now fails to install entirely -- before the user has any
chance to provide configuration.

Fix issue in installing snap cinder-volume due to incomplete config.

Update github workflow to install the built snap.

Closes: #98 